### PR TITLE
Adding getFile implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ The `updateCommitStatus` function will update the commit status for a given repo
 
 The `updateCommitStatus` function returns a promise that will resolve to the data returned back from github.
 
+### getFile
+The parameters required are:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.scmUrl | String | The scmUrl to get permissions on |
+| config.token | String | The github token to check permissions on |
+| config.path | String | The path to the file on github to read |
+| config.ref | String | The reference to the github repo, could be a branch or sha |
+
+The `getFile` function returns a promise that will resolve to the contents of a file that is returned back from github.
+
+The function will reject if the path does not point to a file.
+
 ## Testing
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -41,7 +41,7 @@
   "dependencies": {
     "circuit-fuses": "^1.0.2",
     "github": "^2.4.1",
-    "screwdriver-data-schema": "^10.0.0",
+    "screwdriver-data-schema": "^10.0.3",
     "screwdriver-scm-base": "^1.0.0"
   }
 }


### PR DESCRIPTION
This PR adds in the implementation of the `getFile` function

It takes in an scmUrl, token, path and a reference and will return the contents of the file that is found on github.

We probably needs to come up with an error translation function