### PR TITLE
Overriding stats function (merge #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The `getFile` function returns a promise that will resolve to the contents of a 
 
 The function will reject if the path does not point to a file.
 
+### stats
+Returns circuit breaker statistics for interactions with github
+
 ## Testing
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -228,6 +228,27 @@ class GithubScm extends Scm {
             });
         });
     }
+
+    /**
+    * Retrieve stats for the executor
+    * @method stats
+    * @param  {Response} Object          Object containing stats for the executor
+    */
+    stats() {
+        return {
+            requests: {
+                total: this.breaker.getTotalRequests(),
+                timeouts: this.breaker.getTimeouts(),
+                success: this.breaker.getSuccessfulRequests(),
+                failure: this.breaker.getFailedRequests(),
+                concurrent: this.breaker.getConcurrentRequests(),
+                averageTime: this.breaker.getAverageRequestTime()
+            },
+            breaker: {
+                isClosed: this.breaker.isClosed()
+            }
+        };
+    }
 }
 
 module.exports = GithubScm;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -335,6 +335,45 @@ describe('index', () => {
         });
     });
 
+    describe('stats', () => {
+        let configSuccess;
+
+        beforeEach(() => {
+            configSuccess = {
+                scmUrl: 'git@github.com:screwdriver-cd/models.git',
+                sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
+                buildStatus: 'SUCCESS',
+                token: 'somerandomtoken'
+            };
+        });
+
+        it('returns the correct stats', () => {
+            const err = new Error('githubError');
+
+            githubMock.repos.createStatus.yieldsAsync(err);
+
+            return scm.updateCommitStatus(configSuccess)
+            .then(() => {
+                assert.fail('This should not fail the test');
+            })
+            .catch(() => {
+                assert.deepEqual(scm.stats(), {
+                    requests: {
+                        total: 1,
+                        timeouts: 0,
+                        success: 0,
+                        failure: 1,
+                        concurrent: 0,
+                        averageTime: 1
+                    },
+                    breaker: {
+                        isClosed: true
+                    }
+                });
+            });
+        });
+    });
+
     describe('getFile', () => {
         const scmUrl = 'git@github.com:screwdriver-cd/models.git';
         const content = `IyB3b3JrZmxvdzoKIyAgICAgLSBwdWJsaXNoCgpqb2JzOgogICAgbWFpbjoK\n


### PR DESCRIPTION
This PR is adding in a `stats` function for exposing circuit breaker statistics for the api

The breaker stats are exposed via circuit-fuses: https://github.com/screwdriver-cd/circuit-fuses#get-total-number-requests