### PR TITLE
Use new circuit-fuses that supports retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ class GithubScm extends Scm {
     * Constructor
     * @method constructor
     * @param  {Object} options           Configuration options
+    * @param  {Object} options.retry     Configuration options for circuit breaker retries
+    * @param  {Object} options.breaker   Configuration options for circuit breaker
     * @return {GithubScm}
     */
     constructor(config) {
@@ -67,7 +69,10 @@ class GithubScm extends Scm {
         this.github = new Github();
 
         // eslint-disable-next-line no-underscore-dangle
-        this.breaker = new Breaker(this._githubCommand.bind(this));
+        this.breaker = new Breaker(this._githubCommand.bind(this), {
+            retry: config.retry,
+            breaker: config.breaker
+        });
     }
     /**
     * Format the scmUrl for the specific source control

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
-    "circuit-fuses": "^1.0.2",
+    "circuit-fuses": "^2.0.0",
     "github": "^2.4.1",
     "screwdriver-data-schema": "^10.0.5",
     "screwdriver-scm-base": "^1.0.0"


### PR DESCRIPTION
This PR is pulling in the new version of `circuit-fuses` that supports native retries

Fix the stats tests to make a call that succeeds instead of fails.
