### PR TITLE
Implement v2 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,82 @@ npm install screwdriver-scm-github
 ### Configure
 TODO: allow github values to be configurable
 
+## decorateUrl
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.scmUri | String | Scm uri (ex: `github.com:1234:branchName`) |
+| config.token  | String | Access token for scm |
+
+#### Expected Outcome
+Decorated url in the form of:
+```js
+{
+    url: 'https://github.com/screwdriver-cd/scm-base',
+    name: 'screwdriver-cd/scm-base',
+    branch: 'branchName'
+}
+```
+
+#### Expected Promise response
+1. Resolve with a decorated url object for the repository
+2. Reject if not able to get decorate url
+
+### decorateCommit
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.sha     | String | Commit sha to decorate |
+| config.scmUri        | String | Scm uri (ex: `github.com:1234:branchName`) |
+| config.token | String | Access token for scm |
+
+#### Expected Outcome
+Decorated commit in the form of:
+```js
+{
+    url: 'https://github.com/screwdriver-cd/scm-base/commit/5c3b2cc64ee4bdab73e44c394ad1f92208441411',
+    message: 'Use screwdriver to publish',
+    author: {
+        url: 'https://github.com/d2lam',
+        name: 'Dao Lam',
+        username: 'd2lam',
+        avatar: 'https://avatars3.githubusercontent.com/u/3401924?v=3&s=400'
+    }
+}
+```
+
+#### Expected Promise response
+1. Resolve with a decorate commit object for the repository
+2. Reject if not able to decorate commit
+
+### decorateAuthor
+Required parameters:
+
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.username     | String | Author to decorate |
+| config.token | String | Access token for scm |
+
+#### Expected Outcome
+Decorated author in the form of:
+```js
+{
+    url: 'https://github.com/d2lam',
+    name: 'Dao Lam',
+    username: 'd2lam',
+    avatar: 'https://avatars3.githubusercontent.com/u/3401924?v=3&s=400'
+}
+```
+
+#### Expected Promise response
+1. Resolve with a decorate author object for the repository
+2. Reject if not able to decorate author
+
 ### formatScmUrl
 The parameters required are:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,8 @@
     "circuit-fuses": "^2.0.3",
     "github": "^2.4.1",
     "hoek": "^4.1.0",
-    "screwdriver-data-schema": "^13.0.0",
-    "screwdriver-scm-base": "^1.0.0"
+    "joi": "^9.1.1",
+    "screwdriver-data-schema": "^14.0.5",
+    "screwdriver-scm-base": "^2.0.3"
   }
 }


### PR DESCRIPTION
This PR has `scm-github` adopt the new v2 `scm-base` interface. This switches the use of `scmUrl` with `scmUri`, as well as additional methods for decorating data.


Resolves #15 