### PR TITLE
Fix author lookup, bump dependency versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -372,7 +372,7 @@ class GithubScm extends Scm {
                     action: 'getCommit',
                     token: config.token,
                     params: {
-                        owner: scmInfo.user,
+                        user: scmInfo.user,
                         repo: scmInfo.repo,
                         sha: config.sha
                     }
@@ -388,7 +388,7 @@ class GithubScm extends Scm {
         const authorLookup = commitLookup.then(commitData =>
             this.decorateAuthor({
                 token: config.token,
-                username: commitData.committer.login
+                username: commitData.author.login
             })
         );
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
-    "mockery": "^1.7.0",
+    "eslint-plugin-import": "^2.0.1",
+    "jenkins-mocha": "^3.0.4",
+    "mockery": "^2.0.0",
     "sinon": "^1.17.5"
   },
   "dependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -861,7 +861,7 @@ jobs:
                 commit: {
                     message: 'some commit message that is here'
                 },
-                committer: {
+                author: {
                     login: username
                 },
                 html_url: 'https://link.to/commitDiff'
@@ -887,7 +887,7 @@ jobs:
                     id: scmId
                 });
                 assert.calledWith(githubMock.repos.getCommit, {
-                    owner: repoOwner,
+                    user: repoOwner,
                     repo: repoName,
                     sha
                 });
@@ -912,7 +912,7 @@ jobs:
                 assert.deepEqual(err, testError);
 
                 assert.calledWith(githubMock.repos.getCommit, {
-                    owner: 'banana',
+                    user: 'banana',
                     repo: 'peel',
                     sha
                 });


### PR DESCRIPTION
- `author` should come from *author* login, not *committer* login
- `getCommit` requires `user` as a param, not `owner` (in this version of the github module)
- some devDependencies are very behind

NOTE: will bump `github` version in a different pull request