### PR TITLE
If display name does not exist, default to username

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,9 +343,11 @@ class GithubScm extends Scm {
                     return reject(error);
                 }
 
+                const name = data.name ? data.name : data.login;
+
                 return resolve({
                     avatar: data.avatar_url,
-                    name: data.name,
+                    name,
                     username: data.login,
                     url: data.html_url
                 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -814,6 +814,32 @@ jobs:
             });
         });
 
+        it('defaults to username when display name does not exist', () => {
+            githubMock.users.getForUser.yieldsAsync(null, {
+                login: username,
+                id: 2042,
+                avatar_url: 'https://avatars.githubusercontent.com/u/2042?v=3',
+                html_url: `https://github.com/${username}`,
+                name: null
+            });
+
+            return scm.decorateAuthor({
+                token: 'tokenfordecorateauthor',
+                username
+            }).then((data) => {
+                assert.deepEqual(data, {
+                    avatar: 'https://avatars.githubusercontent.com/u/2042?v=3',
+                    name: username,
+                    url: `https://github.com/${username}`,
+                    username
+                });
+
+                assert.calledWith(githubMock.users.getForUser, {
+                    user: username
+                });
+            });
+        });
+
         it('rejects when failing to communicate with github', () => {
             const testError = new Error('someGithubCommError');
 


### PR DESCRIPTION
It is currently possible for `displayName` to be null, which will break the `data-schema`
Defaulting `displayName` value to `username`