### PR TITLE
Fix bug to use the correct ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,18 @@ The parameters required are:
 | Parameter        | Type  |  Description |
 | :-------------   | :---- | :-------------|
 | config        | Object | Configuration Object |
-| config.scmUrl | String | The scmUrl to get permissions on |
+| config.scmUri | String | The scmUri to get permissions on, e.g. github.com:123456:master |
 | config.token | String | The github token to check permissions on |
 | config.path | String | The path to the file on github to read |
-| config.ref | String | The reference to the github repo, could be a branch or sha |
+| config.ref | String | The scm reference to a github repo, branch or pull request, e.g. git@github.com:screwdriver-cd-test/functional-git.git#pull/1/merge  |
+
+Either `ref` or `scmUri` is required. If both provided, `ref` will be used.
 
 The `getFile` function returns a promise that will resolve to the contents of a file that is returned back from github.
 
 The function will reject if the path does not point to a file.
+
+
 
 ### stats
 Returns circuit breaker statistics for interactions with github

--- a/index.js
+++ b/index.js
@@ -218,7 +218,7 @@ class GithubScm extends Scm {
     * @param  {String}   config.scmUri       The scmUri to get permissions on
     * @param  {String}   config.path         The file in the repo to fetch
     * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @param  {String}   config.ref          The reference to the SCM, either branch or sha
+    * @param  {String}   config.ref          The reference to the SCM
     * @return {Promise}
     */
     _getFile(config) {
@@ -230,7 +230,7 @@ class GithubScm extends Scm {
                     user: scmInfo.user,
                     repo: scmInfo.repo,
                     path: config.path,
-                    ref: config.ref || scmInfo.branch
+                    ref: scmInfo.branch
                 }
             })
         ).then((data) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -476,7 +476,6 @@ jobs:
     #         publish: npm publish && git push origin --tags -q
 `;
         const config = {
-            scmUri,
             path: 'screwdriver.yaml',
             token: 'somerandomtoken',
             ref: 'git@github.com:screwdriver-cd/models.git#pull/453/merge'
@@ -505,7 +504,7 @@ jobs:
                         user: 'screwdriver-cd',
                         repo: 'models',
                         path: config.path,
-                        ref: config.ref
+                        ref: 'pull/453/merge'
                     });
                     assert.calledWith(githubMock.authenticate, {
                         type: 'oauth',
@@ -550,7 +549,7 @@ jobs:
                         user: 'screwdriver-cd',
                         repo: 'models',
                         path: config.path,
-                        ref: config.ref
+                        ref: 'pull/453/merge'
                     });
 
                     assert.calledWith(githubMock.authenticate, {
@@ -576,7 +575,7 @@ jobs:
                     user: 'screwdriver-cd',
                     repo: 'models',
                     path: config.path,
-                    ref: config.ref
+                    ref: 'pull/453/merge'
                 });
 
                 assert.calledWith(githubMock.authenticate, {


### PR DESCRIPTION
- `config.ref` is the whole scm url for PR and not we want to pass in 
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/github.js#L188
