### PR TITLE
Add github webhook signing secret to constructor; add checkSignature() to parseHook()

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ The class has a variety of knobs to tweak when interacting with GitHub.
 | config.oauthClientId | String | OAuth Client ID provided by GitHub application |
 | config.oauthClientSecret | String | OAuth Client Secret provided by GitHub application |
 | config.fusebox ({}) | Object | [Circuit Breaker configuration][circuitbreaker] |
+| config.secret | String | Secret to validate the signature of webhook events |
+
 ```js
 const scm = new GithubScm({
     oauthClientId: 'abcdef',
-    oauthClientSecret: 'hijklm'
+    oauthClientSecret: 'hijklm',
+    secret: 'somesecret'
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ class GithubScm extends Scm {
     * @param  {String}  options.oauthClientId       OAuth Client ID provided by GitHub application
     * @param  {String}  options.oauthClientSecret   OAuth Client Secret provided by GitHub application
     * @param  {Object}  [options.fusebox={}]        Circuit Breaker configuration
+    * @param  {String}  options.secret              Secret to validate the signature of webhook events
     * @return {GithubScm}
     */
     constructor(config = {}) {
@@ -90,7 +91,8 @@ class GithubScm extends Scm {
             https: joi.boolean().optional().default(false),
             oauthClientId: joi.string().required(),
             oauthClientSecret: joi.string().required(),
-            fusebox: joi.object().default({})
+            fusebox: joi.object().default({}),
+            secret: joi.string().required()
         }).unknown(true), 'Invalid config for GitHub');
 
         const githubConfig = {};

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const hoek = require('hoek');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const Scm = require('screwdriver-scm-base');
+const crypto = require('crypto');
 const MATCH_COMPONENT_BRANCH_NAME = 4;
 const MATCH_COMPONENT_REPO_NAME = 3;
 const MATCH_COMPONENT_USER_NAME = 2;
@@ -377,6 +378,27 @@ class GithubScm extends Scm {
     }
 
     /**
+     * Check validity of github webhook event signature
+     * @method _checkSignature
+     * @param   {String}    secret      The secret used to sign the payload
+     * @param   {String}    payload     The payload of the webhook event
+     * @param   {String}    signature   The signature of the webhook event
+     * @returns {boolean}
+     */
+    _checkSignature(secret, payload, signature) {
+        const hmac = crypto.createHmac('sha1', secret);
+
+        hmac.setEncoding('hex');
+        hmac.write(JSON.stringify(payload), 'utf-8');
+        hmac.end();
+
+        const sha = hmac.read();
+        const hash = `sha1=${sha}`;
+
+        return hash === signature;
+    }
+
+    /**
      * Given a SCM webhook payload & its associated headers, aggregate the
      * necessary data to execute a Screwdriver job with.
      * @method _parseHook
@@ -388,6 +410,13 @@ class GithubScm extends Scm {
      *                                   payload
      */
     _parseHook(payloadHeaders, webhookPayload) {
+        const signature = payloadHeaders['x-hub-signature'];
+
+        // eslint-disable-next-line no-underscore-dangle
+        if (!this._checkSignature(this.config.secret, webhookPayload, signature)) {
+            throw new Error('Invalid x-hub-signature');
+        }
+
         const type = payloadHeaders['x-github-event'];
         const hookId = payloadHeaders['x-github-delivery'];
         const checkoutUrl = hoek.reach(webhookPayload, 'repository.ssh_url');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -673,6 +673,7 @@ jobs:
             };
 
             testHeaders = {
+                'x-hub-signature': 'sha1=48a7560319d1ee2ef591e5f5f303e223934d8eac',
                 'x-github-event': 'pull_request',
                 'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
             };
@@ -680,6 +681,7 @@ jobs:
 
         it('parses a payload for a ping event payload', () => {
             testHeaders['x-github-event'] = 'ping';
+            testHeaders['x-hub-signature'] = 'sha1=16632852b90c54f46283a90a7e2d4afb801925e5';
 
             return scm.parseHook(testHeaders, testPayloadPing)
                 .then((result) => {
@@ -709,29 +711,35 @@ jobs:
                 });
         });
 
-        it('parses a payload for a pull request event payload', () =>
-            scm.parseHook(testHeaders, testPayloadOpen)
+        it('parses a payload for a pull request event payload', () => {
+            testHeaders['x-hub-signature'] = 'sha1=568b8bf42185008f5c1c46656a12a20a9dc4341e';
+
+            return scm.parseHook(testHeaders, testPayloadOpen)
                 .then((result) => {
                     commonPullRequestParse.action = 'opened';
                     assert.deepEqual(result, commonPullRequestParse);
-                })
-        );
+                });
+        });
 
-        it('parses a payload for a pull request being closed', () =>
-            scm.parseHook(testHeaders, testPayloadClose)
+        it('parses a payload for a pull request being closed', () => {
+            testHeaders['x-hub-signature'] = 'sha1=42d1596ec3679efc2b5a18c7eb9f2e7c0093d288';
+
+            return scm.parseHook(testHeaders, testPayloadClose)
                 .then((result) => {
                     commonPullRequestParse.action = 'closed';
                     assert.deepEqual(result, commonPullRequestParse);
-                })
-        );
+                });
+        });
 
-        it('parses a payload for a pull request being synchronized', () =>
-            scm.parseHook(testHeaders, testPayloadSync)
+        it('parses a payload for a pull request being synchronized', () => {
+            testHeaders['x-hub-signature'] = 'sha1=25cebb8fff2c10ec8d0712e3ab0163218d375492';
+
+            return scm.parseHook(testHeaders, testPayloadSync)
                 .then((result) => {
                     commonPullRequestParse.action = 'synchronized';
                     assert.deepEqual(result, commonPullRequestParse);
-                })
-        );
+                });
+        });
 
         it('throws an error when parsing an unsupported payload', () => {
             testHeaders['x-github-event'] = 'other_event';
@@ -741,6 +749,17 @@ jobs:
                     assert.fail('This should not fail the tests');
                 }, (err) => {
                     assert.match(err.message, /Event other_event not supported/);
+                });
+        });
+
+        it('throws an error when signature is not valid', () => {
+            testHeaders['x-hub-signature'] = 'sha1=25cebb8fff2c10ec8d0712e3ab0163218d375492';
+
+            return scm.parseHook(testHeaders, testPayloadPush)
+                .then(() => {
+                    assert.fail('This should not fail the tests');
+                }, (err) => {
+                    assert.match(err.message, /Invalid x-hub-signature/);
                 });
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -57,7 +57,8 @@ describe('index', () => {
                 }
             },
             oauthClientId: 'abcdefg',
-            oauthClientSecret: 'hijklmno'
+            oauthClientSecret: 'hijklmno',
+            secret: 'somesecret'
         });
     });
 
@@ -90,7 +91,8 @@ describe('index', () => {
         it('can configure for GitHub.com', () => {
             scm = new GithubScm({
                 oauthClientId: 'abcdefg',
-                oauthClientSecret: 'hijklmno'
+                oauthClientSecret: 'hijklmno',
+                secret: 'somesecret'
             });
             assert.calledWith(githubMockClass, {});
         });
@@ -99,7 +101,8 @@ describe('index', () => {
             scm = new GithubScm({
                 gheHost: 'github.screwdriver.cd',
                 oauthClientId: 'abcdefg',
-                oauthClientSecret: 'hijklmno'
+                oauthClientSecret: 'hijklmno',
+                secret: 'somesecret'
             });
             assert.calledWith(githubMockClass, {
                 host: 'github.screwdriver.cd',
@@ -1056,7 +1059,8 @@ jobs:
             scm = new GithubScm({
                 oauthClientId: 'abcdefg',
                 oauthClientSecret: 'hijklmno',
-                gheHost: 'github.screwdriver.cd'
+                gheHost: 'github.screwdriver.cd',
+                secret: 'somesecret'
             });
 
             return scm.getBellConfiguration().then((config) => {


### PR DESCRIPTION
#As per St.John's suggestions to decouple Screwdriver API from Github
- adds Github webhook signing secret to constructor
- adds checkSignature method in parseHook

Related to https://github.com/screwdriver-cd/screwdriver/pull/313