### PR TITLE
Bump github npm package to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 4.2.0
+
+Bug fixes:
+  * Upgrade node-github package version to v6.
+
 ## 4.1.0
 
+Breaking changes:
   * `parseHook` returns null when webhook event type is not `pull_request` or `repo`; uses promises

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function getInfo(scmUrl) {
     const branch = matched[MATCH_COMPONENT_BRANCH_NAME] || '#master';
 
     return {
-        user: matched[MATCH_COMPONENT_USER_NAME],
+        owner: matched[MATCH_COMPONENT_USER_NAME],
         repo: matched[MATCH_COMPONENT_REPO_NAME],
         host: matched[MATCH_COMPONENT_HOST_NAME],
         branch: branch.slice(1)
@@ -137,13 +137,13 @@ class GithubScm extends Scm {
                 branch: scmBranch,
                 host: scmHost,
                 repo: repoName,
-                user: repoOwner
+                owner: repoOwner
             };
         });
     }
 
     /**
-    * Get a users permissions on a repository
+    * Get a owners permissions on a repository
     * @method _getPermissions
     * @param  {Object}   config            Configuration
     * @param  {String}   config.scmUri     The scmUri to get permissions on
@@ -160,7 +160,7 @@ class GithubScm extends Scm {
                 token: config.token,
                 params: {
                     repo: scmInfo.repo,
-                    user: scmInfo.user
+                    owner: scmInfo.owner
                 }
             })
         ).then(data => data.permissions);
@@ -186,7 +186,7 @@ class GithubScm extends Scm {
                     branch: scmInfo.branch,
                     host: scmInfo.host,
                     repo: scmInfo.repo,
-                    user: scmInfo.user
+                    owner: scmInfo.owner
                 }
             })
         ).then(data => data.commit.sha);
@@ -216,7 +216,7 @@ class GithubScm extends Scm {
                 repo: scmInfo.repo,
                 sha: config.sha,
                 state: STATE_MAP[config.buildStatus] || 'failure',
-                user: scmInfo.user,
+                owner: scmInfo.owner,
                 target_url: config.url
             };
 
@@ -244,7 +244,7 @@ class GithubScm extends Scm {
                 action: 'getContent',
                 token: config.token,
                 params: {
-                    user: scmInfo.user,
+                    owner: scmInfo.owner,
                     repo: scmInfo.repo,
                     path: config.path,
                     ref: config.ref || scmInfo.branch
@@ -327,7 +327,7 @@ class GithubScm extends Scm {
                 action: 'getCommit',
                 token: config.token,
                 params: {
-                    user: scmInfo.user,
+                    owner: scmInfo.owner,
                     repo: scmInfo.repo,
                     sha: config.sha
                 }
@@ -367,11 +367,11 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         }).then((scmInfo) => {
-            const baseUrl = `${scmInfo.host}/${scmInfo.user}/${scmInfo.repo}`;
+            const baseUrl = `${scmInfo.host}/${scmInfo.owner}/${scmInfo.repo}`;
 
             return {
                 branch: scmInfo.branch,
-                name: `${scmInfo.user}/${scmInfo.repo}`,
+                name: `${scmInfo.owner}/${scmInfo.repo}`,
                 url: `https://${baseUrl}/tree/${scmInfo.branch}`
             };
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
-    "github": "^3.0.0",
+    "github": "^6.0.1",
     "hoek": "^4.1.0",
     "joi": "^9.2.0",
     "screwdriver-data-schema": "^14.1.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,7 +136,7 @@ describe('index', () => {
                     assert.deepEqual(data, branch.commit.sha);
 
                     assert.calledWith(githubMock.repos.getBranch, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         host: 'github.com',
                         branch: 'master'
@@ -188,7 +188,7 @@ describe('index', () => {
                 assert.deepEqual(err, error);
 
                 assert.calledWith(githubMock.repos.getBranch, {
-                    user: 'screwdriver-cd',
+                    owner: 'screwdriver-cd',
                     repo: 'models',
                     host: 'github.com',
                     branch: 'master'
@@ -238,7 +238,7 @@ describe('index', () => {
                     });
 
                     assert.calledWith(githubMock.repos.get, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models'
                     });
 
@@ -291,7 +291,7 @@ describe('index', () => {
                     branch: 'targetBranch',
                     host: 'github.com',
                     repo: 'models',
-                    user: 'screwdriver-cd'
+                    owner: 'screwdriver-cd'
                 });
 
                 assert.calledWith(githubMock.repos.getById, {
@@ -363,7 +363,7 @@ describe('index', () => {
                     id: '14052'
                 });
                 assert.calledWith(githubMock.repos.createStatus, {
-                    user: 'screwdriver-cd',
+                    owner: 'screwdriver-cd',
                     repo: 'models',
                     sha: config.sha,
                     state: 'success',
@@ -386,7 +386,7 @@ describe('index', () => {
                     assert.deepEqual(result, data);
 
                     assert.calledWith(githubMock.repos.createStatus, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         sha: config.sha,
                         state: 'success',
@@ -409,7 +409,7 @@ describe('index', () => {
                     assert.deepEqual(result, data);
 
                     assert.calledWith(githubMock.repos.createStatus, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         sha: config.sha,
                         state: 'success',
@@ -432,7 +432,7 @@ describe('index', () => {
                     assert.deepEqual(result, data);
 
                     assert.calledWith(githubMock.repos.createStatus, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         sha: config.sha,
                         state: 'failure',
@@ -460,7 +460,7 @@ describe('index', () => {
                     assert.deepEqual(error, err);
 
                     assert.calledWith(githubMock.repos.createStatus, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         sha: config.sha,
                         state: 'success',
@@ -569,7 +569,7 @@ jobs:
                     assert.deepEqual(data, expectedYaml);
 
                     assert.calledWith(githubMock.repos.getContent, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         path: config.path,
                         ref: config.ref
@@ -589,7 +589,7 @@ jobs:
                     assert.deepEqual(data, expectedYaml);
 
                     assert.calledWith(githubMock.repos.getContent, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         path: configNoRef.path,
                         ref: 'master'
@@ -614,7 +614,7 @@ jobs:
                     assert.strictEqual(err.message, expectedErrorMessage);
 
                     assert.calledWith(githubMock.repos.getContent, {
-                        user: 'screwdriver-cd',
+                        owner: 'screwdriver-cd',
                         repo: 'models',
                         path: config.path,
                         ref: config.ref
@@ -640,7 +640,7 @@ jobs:
             })
             .catch((error) => {
                 assert.calledWith(githubMock.repos.getContent, {
-                    user: 'screwdriver-cd',
+                    owner: 'screwdriver-cd',
                     repo: 'models',
                     path: config.path,
                     ref: config.ref
@@ -769,7 +769,7 @@ jobs:
         const repoInfo = {
             host: 'github.com',
             repo: 'theCaptain',
-            user: 'iAm'
+            owner: 'iAm'
         };
 
         beforeEach(() => {
@@ -973,7 +973,7 @@ jobs:
                     id: scmId
                 });
                 assert.calledWith(githubMock.repos.getCommit, {
-                    user: repoOwner,
+                    owner: repoOwner,
                     repo: repoName,
                     sha
                 });
@@ -998,7 +998,7 @@ jobs:
                 assert.deepEqual(err, testError);
 
                 assert.calledWith(githubMock.repos.getCommit, {
-                    user: 'banana',
+                    owner: 'banana',
                     repo: 'peel',
                     sha
                 });


### PR DESCRIPTION
Screwdriver API uses github package v5, but the scm-github repo is still on v3. Updating scm-github so the two are using the same version.
