### PR TITLE
Fix bug: v6 getForUser requires params with username as key

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ class GithubScm extends Scm {
             action: 'getForUser',
             scopeType: 'users',
             token: config.token,
-            params: { user: config.username }
+            params: { username: config.username }
         }).then((data) => {
             const name = data.name ? data.name : data.login;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -869,7 +869,7 @@ jobs:
                 });
 
                 assert.calledWith(githubMock.users.getForUser, {
-                    user: username
+                    username
                 });
             });
         });
@@ -895,7 +895,7 @@ jobs:
                 });
 
                 assert.calledWith(githubMock.users.getForUser, {
-                    user: username
+                    username
                 });
             });
         });
@@ -914,7 +914,7 @@ jobs:
                 assert.deepEqual(err, testError);
 
                 assert.calledWith(githubMock.users.getForUser, {
-                    user: username
+                    username
                 });
             });
         });
@@ -978,7 +978,7 @@ jobs:
                     sha
                 });
                 assert.calledWith(githubMock.users.getForUser, {
-                    user: username
+                    username
                 });
             });
         });


### PR DESCRIPTION
- v6 github requires `username` as key instead of `user`
- http://mikedeboer.github.io/node-github/#api-orgs-getForUser