### PR TITLE
Add method to get checkout commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 4.4.0
+
+Features:
+  * Implement `_getCheckoutCommand` method defined in [scm-base](https://github.com/screwdriver-cd/scm-base).
+
+## 4.3.0
+
+Bug fixes:
+  * Upgrade data-schema package version to v15.
+  * Better error message when repo does not exist.
+  * Gracefully handle missing user.
+
 ## 4.2.0
 
 Bug fixes:
@@ -8,4 +20,4 @@ Bug fixes:
 ## 4.1.0
 
 Breaking changes:
-  * `parseHook` returns null when webhook event type is not `pull_request` or `repo`; uses promises
+  * `parseHook` returns null when webhook event type is not `pull_request` or `repo`; uses promises.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,6 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^2.0.1",
     "jenkins-mocha": "^3.0.4",
     "mockery": "^2.0.0",
     "sinon": "^1.17.5"
@@ -43,7 +42,7 @@
     "github": "^6.0.1",
     "hoek": "^4.1.0",
     "joi": "^9.2.0",
-    "screwdriver-data-schema": "^15.0.0",
-    "screwdriver-scm-base": "^2.3.0"
+    "screwdriver-data-schema": "^15.3.0",
+    "screwdriver-scm-base": "^2.4.0"
   }
 }

--- a/test/data/commands.json
+++ b/test/data/commands.json
@@ -1,0 +1,4 @@
+{
+    "name": "checkout-code",
+    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard 12345 && echo Reset to 12345 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
+}

--- a/test/data/prCommands.json
+++ b/test/data/prCommands.json
@@ -1,0 +1,4 @@
+{
+    "name": "checkout-code",
+    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard branchName && echo Reset to branchName && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with branchName && git fetch origin pull/3/head:pr && git merge --no-edit 12345"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,6 +10,8 @@ const testPayloadPush = require('./data/github.push.json');
 const testPayloadSync = require('./data/github.pull_request.synchronize.json');
 const testPayloadBadAction = require('./data/github.pull_request.badAction.json');
 const testPayloadPing = require('./data/github.ping.json');
+const testCommands = require('./data/commands.json');
+const testPrCommands = require('./data/prCommands.json');
 
 sinon.assert.expose(assert, {
     prefix: ''
@@ -110,6 +112,32 @@ describe('index', () => {
                 protocol: 'https',
                 pathPrefix: '/api/v3'
             });
+        });
+    });
+
+    describe('getCheckoutCommand', () => {
+        const config = {
+            branch: 'branchName',
+            host: 'github.com',
+            org: 'screwdriver-cd',
+            repo: 'guide',
+            sha: '12345'
+        };
+
+        it('promises to get the checkout command for the pipeline branch', () =>
+            scm.getCheckoutCommand(config)
+                .then((command) => {
+                    assert.deepEqual(command, testCommands);
+                })
+        );
+
+        it('promises to get the checkout command for a pull request', () => {
+            config.prRef = 'pull/3/merge';
+
+            return scm.getCheckoutCommand(config)
+                .then((command) => {
+                    assert.deepEqual(command, testPrCommands);
+                });
         });
     });
 


### PR DESCRIPTION
The launcher is currently hardcoded to checkout repositories from github.com. We want to move that logic into the scm plugins. Adding a method to get checkout commands in the scm-github.

Related to https://github.com/screwdriver-cd/scm-base/pull/28
Related to https://github.com/screwdriver-cd/screwdriver/issues/312
