### PR TITLE
[3] Checkout command name should be sd-checkout-code

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ class GithubScm extends Scm {
         }
 
         return Promise.resolve({
-            name: 'checkout-code',
+            name: 'sd-checkout-code',
             command: command.join(' && ')
         });
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "github": "^6.0.1",
     "hoek": "^4.1.0",
     "joi": "^9.2.0",
-    "screwdriver-data-schema": "^15.3.0",
+    "screwdriver-data-schema": "^15.4.0",
     "screwdriver-scm-base": "^2.4.0"
   }
 }

--- a/test/data/commands.json
+++ b/test/data/commands.json
@@ -1,4 +1,4 @@
 {
-    "name": "checkout-code",
+    "name": "sd-checkout-code",
     "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard 12345 && echo Reset to 12345 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
 }

--- a/test/data/prCommands.json
+++ b/test/data/prCommands.json
@@ -1,4 +1,4 @@
 {
-    "name": "checkout-code",
+    "name": "sd-checkout-code",
     "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard branchName && echo Reset to branchName && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with branchName && git fetch origin pull/3/head:pr && git merge --no-edit 12345"
 }


### PR DESCRIPTION
Adding `sd-` as a prefix for the command name to avoid stepping on user configs

Blocked by https://github.com/screwdriver-cd/scm-base/pull/29