### PR TITLE
Use absolute path for git clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,8 +167,8 @@ class GithubScm extends Scm {
 
         // Git clone
         command.push(`echo Cloning ${checkoutUrl}, on branch ${config.branch}`);
-        command.push(`git clone --quiet --progress --branch ${config.branch} ${checkoutUrl}`);
-        command.push(`cd ${config.repo}`);
+        command.push(`git clone --quiet --progress --branch ${config.branch} `
+            + `${checkoutUrl} $SD_SOURCE_DIR`);
         // Reset to SHA
         command.push(`git reset --hard ${checkoutRef}`);
         command.push(`echo Reset to ${checkoutRef}`);

--- a/test/data/commands.json
+++ b/test/data/commands.json
@@ -1,4 +1,4 @@
 {
     "name": "sd-checkout-code",
-    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard 12345 && echo Reset to 12345 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
+    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide $SD_SOURCE_DIR && git reset --hard 12345 && echo Reset to 12345 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"
 }

--- a/test/data/prCommands.json
+++ b/test/data/prCommands.json
@@ -1,4 +1,4 @@
 {
     "name": "sd-checkout-code",
-    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard branchName && echo Reset to branchName && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with branchName && git fetch origin pull/3/head:pr && git merge --no-edit 12345"
+    "command": "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide $SD_SOURCE_DIR && git reset --hard branchName && echo Reset to branchName && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd && echo Fetching PR and merging with branchName && git fetch origin pull/3/head:pr && git merge --no-edit 12345"
 }


### PR DESCRIPTION
- Switching to using an absolute path when running `git clone` so the src dir will be consistent in the launcher
- SD_SOURCE_DIR is an environment variable set in the launcher
https://github.com/screwdriver-cd/launcher/blob/master/launch.go#L236

Related to https://github.com/screwdriver-cd/screwdriver/issues/312