### PR TITLE
fix: use semantic-release to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # scm-github
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
-> Github implementation for the scm-base class
-
-This scm plugin extends the [scm-base-class], and provides methods to fetch and update data in github.
+> This scm plugin extends the [scm-base-class], and provides methods to fetch and update data in github.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive"
+    "test": "jenkins-mocha --recursive",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
@@ -35,7 +36,8 @@
     "eslint-config-screwdriver": "^2.0.0",
     "jenkins-mocha": "^3.0.4",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "semantic-release": "^6.3.2"
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
@@ -44,5 +46,11 @@
     "joi": "^9.2.0",
     "screwdriver-data-schema": "^15.4.0",
     "screwdriver-scm-base": "^2.4.0"
+  },
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
   }
 }

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,11 +12,10 @@ jobs:
 
     publish:
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - install-ci: npm install npm-auto-version
-            - publish-npm: ./ci/publish.sh
+            - install: npm install
+            - publish: npm run semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
-            - GIT_KEY
+            - GH_TOKEN


### PR DESCRIPTION
- use `semantic-release` to bump version, publish to npm and push tags back to github
- changed the REAMED to make it consistent with scm-bitbucket