### PR TITLE
fix: update github to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
-    "github": "^6.0.1",
+    "github": "^7.0.1",
     "hoek": "^4.1.0",
     "joi": "^10.0.5",
     "screwdriver-data-schema": "^15.4.0",


### PR DESCRIPTION
Breaking changes do not affect us. 

Release note: https://github.com/mikedeboer/node-github/blob/master/CHANGELOG.md
Related https://github.com/screwdriver-cd/screwdriver/pull/383/files