### PR TITLE
Implementing _getOpenedPRs

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,6 +303,37 @@ class GithubScm extends Scm {
     }
 
     /**
+     * Get a list of objects which consist of opened PR names and refs
+     * @method _getOpenedPRs
+     * @param  {Object}      config
+     * @param  {String}      config.scmUri  The scmUri to get opened PRs from
+     * @param  {String}      config.token   The token used to authenticate with the SCM
+     * @return {Promise}
+     */
+    _getOpenedPRs(config) {
+        return this.lookupScmUri({
+            scmUri: config.scmUri,
+            token: config.token
+        }).then(scmInfo =>
+            this.breaker.runCommand({
+                action: 'getAll',
+                scopeType: 'pullRequests',
+                token: config.token,
+                params: {
+                    owner: scmInfo.owner,
+                    repo: scmInfo.repo,
+                    state: 'open'
+                }
+            })
+        ).then(pullRequests =>
+            pullRequests.map(pullRequestInfo => ({
+                name: `PR-${pullRequestInfo.number}`,
+                ref: `pull/${pullRequestInfo.number}/merge`
+            }))
+        );
+    }
+
+    /**
     * Get a owners permissions on a repository
     * @method _getPermissions
     * @param  {Object}   config            Configuration

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -2,3 +2,4 @@ extends: screwdriver
 rules:
     func-names: off
     prefer-arrow-callback: off
+    no-underscore-dangle: off

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1186,7 +1186,7 @@ jobs:
         });
     });
 
-    describe('_addWebhook', () => {
+    describe('addWebhook', () => {
         const webhookConfig = {
             scmUri: 'github.com:1263:branchName',
             token: 'fakeToken',
@@ -1207,9 +1207,7 @@ jobs:
             githubMock.repos.getHooks.yieldsAsync(null, []);
             githubMock.repos.createHook.yieldsAsync(null);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(() => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.authenticate, sinon.match({
                     token: 'fakeToken'
                 }));
@@ -1234,9 +1232,7 @@ jobs:
         it('updates a pre-existing hook', () => {
             githubMock.repos.editHook.yieldsAsync(null);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(() => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.repos.getHooks, {
                     owner: 'dolores',
                     repo: 'violentdelights',
@@ -1269,9 +1265,7 @@ jobs:
             githubMock.repos.getHooks.onCall(0).yieldsAsync(null, invalidHooks);
             githubMock.repos.editHook.yieldsAsync(null);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(() => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.repos.getHooks, {
                     owner: 'dolores',
                     repo: 'violentdelights',
@@ -1299,9 +1293,7 @@ jobs:
 
             githubMock.repos.getHooks.yieldsAsync(testError);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(assert.fail, (err) => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(assert.fail, (err) => {
                 assert.equal(err, testError);
             });
         });
@@ -1312,9 +1304,7 @@ jobs:
             githubMock.repos.getHooks.yieldsAsync(null, []);
             githubMock.repos.createHook.yieldsAsync(testError);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(assert.fail, (err) => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(assert.fail, (err) => {
                 assert.equal(err, testError);
             });
         });
@@ -1324,9 +1314,7 @@ jobs:
 
             githubMock.repos.editHook.yieldsAsync(testError);
 
-            /* eslint-disable no-underscore-dangle */
-            return scm._addWebhook(webhookConfig).then(assert.fail, (err) => {
-            /* eslint-enable no-underscore-dangle */
+            return scm.addWebhook(webhookConfig).then(assert.fail, (err) => {
                 assert.equal(err, testError);
             });
         });


### PR DESCRIPTION
Implementing the `_getOpenedPRs` method that was introduced with screwdriver-cd/scm-base#37. 

This will look up the opened PRs against a specific repository. It will then return a payload of a few data points `name`, `prRef`.

Related to screwdriver-cd/screwdriver#417