### PR TITLE
fix: update github dependency to version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
-    "github": "^7.0.1",
+    "github": "^8.1.1",
     "hoek": "^4.1.0",
     "joi": "^10.0.5",
     "screwdriver-data-schema": "^16.0.0",


### PR DESCRIPTION
Update this to be up to date with the API: https://github.com/screwdriver-cd/screwdriver/blob/master/package.json#L103