### PR TITLE
fix: change commit context for PR jobs

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,7 +414,8 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         }).then((scmInfo) => {
-            const context = config.jobName ? `Screwdriver/${config.jobName}` : 'Screwdriver';
+            const jobName = config.jobName && /^PR/.test(config.jobName) ? 'PR' : config.jobName;
+            const context = jobName ? `Screwdriver/${jobName}` : 'Screwdriver';
             const params = {
                 context,
                 description: DESCRIPTION_MAP[config.buildStatus],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -458,7 +458,7 @@ describe('index', function () {
             })
         );
 
-        it('sets a better context when jobName passed in', () => {
+        it('sets context for PR when jobName passed in', () => {
             config.jobName = 'PR-15';
 
             return scm.updateCommitStatus(config)
@@ -471,7 +471,7 @@ describe('index', function () {
                         sha: config.sha,
                         state: 'success',
                         description: 'Everything looks good!',
-                        context: 'Screwdriver/PR-15',
+                        context: 'Screwdriver/PR',
                         target_url: 'https://foo.bar'
                     });
                     assert.calledWith(githubMock.authenticate, {
@@ -481,25 +481,19 @@ describe('index', function () {
                 });
         });
 
-        it('sets a better context when jobName passed in', () => {
-            config.jobName = 'PR-15';
+        it('sets context for regular job when jobName passed in', () => {
+            config.jobName = 'main';
 
             return scm.updateCommitStatus(config)
-                .then((result) => {
-                    assert.deepEqual(result, data);
-
+                .then(() => {
                     assert.calledWith(githubMock.repos.createStatus, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
                         sha: config.sha,
                         state: 'success',
                         description: 'Everything looks good!',
-                        context: 'Screwdriver/PR-15',
+                        context: 'Screwdriver/main',
                         target_url: 'https://foo.bar'
-                    });
-                    assert.calledWith(githubMock.authenticate, {
-                        type: 'oauth',
-                        token: config.token
                     });
                 });
         });


### PR DESCRIPTION
This resolves https://github.com/screwdriver-cd/screwdriver/issues/594

@stjohnjohnson  I'm not adding `pipelineId` because it's not available in the param. If we want that, we would need to change it in the model. I think `Screwdriver/main` or `Screwdriver/PR` is sufficient. 