### PR TITLE
feat(587): Add lastCommitMessage to parsed hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -678,6 +678,7 @@ class GithubScm extends Scm {
                 sha: hoek.reach(webhookPayload, 'after'),
                 type: 'repo',
                 username: hoek.reach(webhookPayload, 'sender.login'),
+                lastCommitMessage: hoek.reach(webhookPayload, 'head_commit.message') || '',
                 hookId
             });
         default:

--- a/test/data/github.push.json
+++ b/test/data/github.push.json
@@ -40,7 +40,7 @@
     "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
     "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
     "distinct": true,
-    "message": "Update README.md",
+    "message": "lastcommitmessage",
     "timestamp": "2015-05-05T19:40:15-04:00",
     "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
     "author": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -750,7 +750,7 @@ jobs:
             };
 
             testHeaders = {
-                'x-hub-signature': 'sha1=5a69278cd3e1ced08f8af4f96da683410a3cefff',
+                'x-hub-signature': 'sha1=a72eab99ad7f36f582f224df8d735091b06f1802',
                 'x-github-event': 'pull_request',
                 'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
             };
@@ -768,6 +768,7 @@ jobs:
                         sha: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
                         type: 'repo',
                         username: 'baxterthehacker2',
+                        lastCommitMessage: 'lastcommitmessage',
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
                     });
                 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I'd like to implement the skipping builds feature (screwdriver-cd/screwdriver#587)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds lastCommitMessage to the result of `parseHook`.
If this PR is approved, I'll change [around this code](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/index.js#L397) to check if the last commit message contains "[skip ci]". I'll also change other scm plugins.

## References

- issue: screwdriver-cd/screwdriver#587
- webhook spec: https://developer.github.com/v3/activity/events/types/#pushevent