### PR TITLE
fix: use jobName as context on create status

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,12 +422,8 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         }).then((scmInfo) => {
-            let context = `Screwdriver/${config.pipelineId}/`;
-
-            context += /^PR/.test(config.jobName) ? 'PR' : config.jobName;
-
             const params = {
-                context,
+                context: `Screwdriver/${config.pipelineId}/${config.jobName}`,
                 description: DESCRIPTION_MAP[config.buildStatus],
                 repo: scmInfo.repo,
                 sha: config.sha,

--- a/index.js
+++ b/index.js
@@ -422,8 +422,10 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         }).then((scmInfo) => {
+            const jobName = config.jobName.replace(/^PR-\d+/g, 'PR');
+
             const params = {
-                context: `Screwdriver/${config.pipelineId}/${config.jobName}`,
+                context: `Screwdriver/${config.pipelineId}/${jobName}`,
                 description: DESCRIPTION_MAP[config.buildStatus],
                 repo: scmInfo.repo,
                 sha: config.sha,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -473,7 +473,7 @@ describe('index', function () {
                         sha: config.sha,
                         state: 'success',
                         description: 'Everything looks good!',
-                        context: 'Screwdriver/675/PR',
+                        context: 'Screwdriver/675/PR-15',
                         target_url: 'https://foo.bar'
                     });
                     assert.calledWith(githubMock.authenticate, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -461,7 +461,7 @@ describe('index', function () {
         );
 
         it('sets context for PR when jobName passed in', () => {
-            config.jobName = 'PR-15';
+            config.jobName = 'PR-15:test';
 
             return scm.updateCommitStatus(config)
                 .then((result) => {
@@ -473,7 +473,7 @@ describe('index', function () {
                         sha: config.sha,
                         state: 'success',
                         description: 'Everything looks good!',
-                        context: 'Screwdriver/675/PR-15',
+                        context: 'Screwdriver/675/PR:test',
                         target_url: 'https://foo.bar'
                     });
                     assert.calledWith(githubMock.authenticate, {
@@ -560,7 +560,8 @@ describe('index', function () {
                 sha: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f',
                 buildStatus: 'SUCCESS',
                 token: 'somerandomtoken',
-                url: 'https://foo.bar'
+                url: 'https://foo.bar',
+                jobName: 'main'
             };
 
             githubMock.repos.getById.yieldsAsync(null, {


### PR DESCRIPTION
## Context
A user uses multiple jobs triggered by pull request like this:
![image](https://user-images.githubusercontent.com/3445553/33371366-cb7d4fd4-d53d-11e7-8c50-ae6de6c997f0.png)
Only `Screwdriver/<pipeline_id>/PR` status is created and updated when the user open pull request. This causes when the first pull request job is finished then the status become `success` in spite of other builds running. 
I think multiple statuses should be created and updated for checking PR job statuses individually.

## Objective
~~Use jobName directly in the context.~~
Use jobName in the context like: `Screwdriver/123/PR:test`

## misc
GitHub API: https://developer.github.com/v3/repos/statuses/#create-a-status