### PR TITLE
fix(881): Ignore errors from github with error code 422

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,6 +441,10 @@ class GithubScm extends Scm {
                 action: 'createStatus',
                 token: config.token,
                 params
+            }).catch((err) => {
+                if (err.code !== 422) {
+                    throw err;
+                }
             });
         });
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -524,6 +524,49 @@ describe('index', function () {
                 });
         });
 
+        it('catches and discards github command error when it has a 422 error code', () => {
+            const errMsg = JSON.stringify({
+                message: 'Validation Failed',
+                errors: [
+                    {
+                        resource: 'Status',
+                        code: 'custom',
+                        message: 'This SHA and context has reached the maximum number of statuses.'
+                    }
+                ],
+                // eslint-disable-next-line max-len
+                documentation_url: 'https://developer.github.com/enterprise/2.10/v3/repos/statuses/#create-a-status'
+            });
+            const err = new Error(errMsg);
+
+            err.code = 422;
+            githubMock.repos.createStatus.yieldsAsync(err);
+
+            config.buildStatus = 'FAILURE';
+
+            return scm.updateCommitStatus(config)
+                .then((result) => {
+                    assert.deepEqual(result, undefined);
+
+                    assert.calledWith(githubMock.repos.createStatus, {
+                        owner: 'screwdriver-cd',
+                        repo: 'models',
+                        sha: config.sha,
+                        state: 'failure',
+                        description: 'Did not work as expected.',
+                        context: 'Screwdriver/675/main',
+                        target_url: 'https://foo.bar'
+                    });
+                    assert.calledWith(githubMock.authenticate, {
+                        type: 'oauth',
+                        token: config.token
+                    });
+                })
+                .catch(() => {
+                    assert(false, 'No error should be thrown if error code is 422');
+                });
+        });
+
         it('returns an error when github command fails', () => {
             const err = new Error('githubError');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -524,7 +524,7 @@ describe('index', function () {
                 });
         });
 
-        it('catches and discards github command error when it has a 422 error code', () => {
+        it('catches and discards github command errors when it has a 422 error code', () => {
             const errMsg = JSON.stringify({
                 message: 'Validation Failed',
                 errors: [
@@ -563,7 +563,7 @@ describe('index', function () {
                     });
                 })
                 .catch(() => {
-                    assert(false, 'No error should be thrown if error code is 422');
+                    assert(false, 'Error should be handled if error code is 422');
                 });
         });
 


### PR DESCRIPTION
# Context

From https://developer.github.com/v3/repos/statuses/

>Note: there is a limit of 1000 statuses per sha and context within a repository. Attempts to create more than 1000 statuses will result in a validation error.

There are build monitoring pipelines that run periodically, and reach the limit noted above. When the error is thrown, the pipeline stops entirely. See the [old PR](https://github.com/screwdriver-cd/models/pull/228) for full error.

# Objective

Allow pipelines to continue if the 1000 statuses per SHA limit is reached.

# References

* Issue: https://github.com/screwdriver-cd/screwdriver/issues/881
* Old PR: https://github.com/screwdriver-cd/models/pull/228