### PR TITLE
[DNM] fix: Update github package to @octokit/rest

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const Breaker = require('circuit-fuses');
-const Github = require('github');
+const Github = require('@octokit/rest');
 const hoek = require('hoek');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
+    "@octokit/rest": "^15.1.9",
     "circuit-fuses": "^2.0.3",
-    "github": "^8.1.1",
     "hoek": "^5.0.3",
     "joi": "^13.0.0",
     "screwdriver-data-schema": "^18.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -59,7 +59,7 @@ describe('index', function () {
         };
         githubMockClass = sinon.stub().returns(githubMock);
 
-        mockery.registerMock('github', githubMockClass);
+        mockery.registerMock('@octokit/rest', githubMockClass);
 
         /* eslint-disable global-require */
         GithubScm = require('../index');


### PR DESCRIPTION
# Context

The `github` package on NPM was renamed to `@octokit/rest` on January 17th, 2018.

# Objective

Update source code to use the `@octokit/rest` package.