### PR TITLE
feat(911): Add getChangedFiles [3]

### DIFF
--- a/index.js
+++ b/index.js
@@ -647,29 +647,29 @@ class GithubScm extends Scm {
      * @param  {String}   config.token           Service token to authenticate with Github
      * @return {Promise}
      */
-    _getChangedFiles({ type, webhookPayload, token }) {
+    _getChangedFiles({ type, payload, token }) {
         if (type === 'pr') {
             return this.breaker.runCommand({
                 action: 'getFiles',
                 scopeType: 'pullRequests',
                 token,
                 params: {
-                    owner: hoek.reach(webhookPayload, 'repository.owner.login'),
-                    repo: hoek.reach(webhookPayload, 'repository.name'),
-                    number: hoek.reach(webhookPayload, 'number')
+                    owner: hoek.reach(payload, 'repository.owner.login'),
+                    repo: hoek.reach(payload, 'repository.name'),
+                    number: hoek.reach(payload, 'number')
                 }
             }).then((data) => {
                 const fileNames = [];
 
                 data.forEach((file) => {
-                    fileNames.push(file.fileName);
+                    fileNames.push(file.filename);
                 });
 
                 return fileNames;
             });
         }
         if (type === 'repo') {
-            return hoek.reach(webhookPayload, 'head_commit.modified');
+            return hoek.reach(payload, 'head_commit.modified');
         }
 
         return [];

--- a/index.js
+++ b/index.js
@@ -638,6 +638,44 @@ class GithubScm extends Scm {
     }
 
     /**
+     * Get the changed files from a Git event
+     * @method _getChangedFiles
+     * @param  {Object}   config                 Configuration object
+     * @param  {String}   config.type            Can be 'pr' or 'repo'
+     * @param  {Object}   config.webhookPayload  The webhook payload received from the
+     *                                           SCM service.
+     * @param  {String}   config.token           Service token to authenticate with Github
+     * @return {Promise}
+     */
+    _getChangedFiles({ type, webhookPayload, token }) {
+        if (type === 'pr') {
+            return this.breaker.runCommand({
+                action: 'getFiles',
+                scopeType: 'pullRequests',
+                token,
+                params: {
+                    owner: hoek.reach(webhookPayload, 'repository.owner.login'),
+                    repo: hoek.reach(webhookPayload, 'repository.name'),
+                    number: hoek.reach(webhookPayload, 'number')
+                }
+            }).then((data) => {
+                const fileNames = [];
+
+                data.forEach((file) => {
+                    fileNames.push(file.fileName);
+                });
+
+                return fileNames;
+            });
+        }
+        if (type === 'repo') {
+            return hoek.reach(webhookPayload, 'head_commit.modified');
+        }
+
+        return [];
+    }
+
+    /**
      * Given a SCM webhook payload & its associated headers, aggregate the
      * necessary data to execute a Screwdriver job with.
      * @method _parseHook

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "github": "^8.1.1",
     "hoek": "^5.0.3",
     "joi": "^13.0.0",
-    "screwdriver-data-schema": "^18.0.0",
-    "screwdriver-scm-base": "^3.0.0"
+    "screwdriver-data-schema": "^18.13.0",
+    "screwdriver-scm-base": "^4.0.1"
   },
   "release": {
     "debug": false,

--- a/test/data/github.pull_request.files.json
+++ b/test/data/github.pull_request.files.json
@@ -1,0 +1,26 @@
+[
+    {
+        "sha": "517b4fbcb418e0e12e9e5fe34a1f130da2cde5d6",
+        "filename": "README.md",
+        "status": "modified",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/tkyi/mytest/blob/37825f865fe7ef0ffaee0c04b6b9e7994f42ec39/README.md",
+        "raw_url": "https://github.com/tkyi/mytest/raw/37825f865fe7ef0ffaee0c04b6b9e7994f42ec39/README.md",
+        "contents_url": "https://api.github.com/repos/tkyi/mytest/contents/README.md?ref=37825f865fe7ef0ffaee0c04b6b9e7994f42ec39",
+        "patch": "@@ -2,3 +2,4 @@\n \n meow\n hi\n+meow"
+    },
+    {
+        "sha": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
+        "filename": "folder/folder2/hi",
+        "status": "added",
+        "additions": 1,
+        "deletions": 0,
+        "changes": 1,
+        "blob_url": "https://github.com/tkyi/mytest/blob/37825f865fe7ef0ffaee0c04b6b9e7994f42ec39/folder/folder2/hi",
+        "raw_url": "https://github.com/tkyi/mytest/raw/37825f865fe7ef0ffaee0c04b6b9e7994f42ec39/folder/folder2/hi",
+        "contents_url": "https://api.github.com/repos/tkyi/mytest/contents/folder/folder2/hi?ref=37825f865fe7ef0ffaee0c04b6b9e7994f42ec39",
+        "patch": "@@ -0,0 +1 @@\n+hi"
+    }
+]

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -790,7 +790,7 @@ jobs:
             return scm.getChangedFiles({
                 type,
                 token,
-                webhookPayload: testPayloadPush
+                payload: testPayloadPush
             })
                 .then((result) => {
                     assert.deepEqual(result, ['README.md']);
@@ -804,7 +804,7 @@ jobs:
             return scm.getChangedFiles({
                 type,
                 token,
-                webhookPayload: testPayloadOpen
+                payload: testPayloadOpen
             })
                 .then((result) => {
                     assert.deepEqual(result, ['README.md', 'folder/folder2/hi']);
@@ -812,12 +812,12 @@ jobs:
         });
 
         it('returns empty array for an event payload that is not type repo or pr', () => {
-            type = 'banana';
+            type = 'ping';
 
             return scm.getChangedFiles({
                 type,
                 token,
-                webhookPayload: testPayloadOpen
+                payload: testPayloadOpen
             })
                 .then((result) => {
                     assert.deepEqual(result, []);
@@ -833,7 +833,7 @@ jobs:
             return scm.getChangedFiles({
                 type,
                 token,
-                webhookPayload: testPayloadOpen
+                payload: testPayloadOpen
             }).then(() => {
                 assert.fail('This should not fail the test');
             }, (err) => {
@@ -1701,7 +1701,7 @@ jobs:
             };
         });
 
-        it('returns a true for a pull request event payload', () => {
+        it('returns true for a pull request event payload', () => {
             testHeaders['x-hub-signature'] = 'sha1=41d0508ffed278fde2fd5a84fd75c109a7039f90';
 
             return scm.canHandleWebhook(testHeaders, testPayloadOpen)
@@ -1710,7 +1710,7 @@ jobs:
                 });
         });
 
-        it('returns a true for a pull request being closed', () => {
+        it('returns true for a pull request being closed', () => {
             testHeaders['x-hub-signature'] = 'sha1=2d51c3a4eaab65832c119ec3db951de54ec38736';
 
             return scm.canHandleWebhook(testHeaders, testPayloadClose)
@@ -1719,7 +1719,7 @@ jobs:
                 });
         });
 
-        it('returns a true for a pull request being synchronized', () => {
+        it('returns true for a pull request being synchronized', () => {
             testHeaders['x-hub-signature'] = 'sha1=583afb7551c9bc412f7496bc840b027931e97846';
 
             return scm.canHandleWebhook(testHeaders, testPayloadSync)
@@ -1728,7 +1728,7 @@ jobs:
                 });
         });
 
-        it('returns a true for a push event payload', () => {
+        it('returns true for a push event payload', () => {
             testHeaders['x-github-event'] = 'push';
 
             return scm.canHandleWebhook(testHeaders, testPayloadPush)
@@ -1737,7 +1737,7 @@ jobs:
                 });
         });
 
-        it('returns a false when signature is not valid', () => {
+        it('returns false when signature is not valid', () => {
             testHeaders['x-hub-signature'] = 'sha1=25cebb8fff2c10ec8d0712e3ab0163218d375492';
 
             return scm.canHandleWebhook(testHeaders, testPayloadPing)
@@ -1746,7 +1746,7 @@ jobs:
                 });
         });
 
-        it('returns a false when different github payload', () => {
+        it('returns false when different github payload', () => {
             scm = new GithubScm({
                 oauthClientId: 'abcdefg',
                 oauthClientSecret: 'hijklmno',


### PR DESCRIPTION
## Context
We'd like to add a method that gets a list of changed files when a push or PR occurs in Git. This will allow for subdirectory support.

## Objective
This PR:
- adds **getChangedFiles** method

Note: probably want to bump major version

## Related links
- Blocked by https://github.com/screwdriver-cd/data-schema/pull/215, https://github.com/screwdriver-cd/scm-base/pull/49
- Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911