### PR TITLE
refactor(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ class GithubScm extends Scm {
     * @param  {String}      [options.scopeType]  Type of request to make. Default is 'repos'
     * @param  {Function}    callback             Callback function from github API
     */
-    _githubCommand(options) {
+    _githubCommand(options, callback) {
         this.github.authenticate({
             type: 'oauth',
             token: options.token

--- a/index.js
+++ b/index.js
@@ -140,13 +140,13 @@ class GithubScm extends Scm {
     async lookupScmUri(config) {
         const [scmHost, scmId, scmBranch] = config.scmUri.split(':');
 
-        const data = await this.breaker.runCommand({
+        const repo = await this.breaker.runCommand({
             action: 'getById',
             token: config.token,
             params: { id: scmId }
         });
 
-        const [repoOwner, repoName] = data.full_name.split('/');
+        const [repoOwner, repoName] = repo.full_name.split('/');
 
         return {
             branch: scmBranch,
@@ -242,7 +242,6 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const hookInfo = await this._findWebhook({
             scmInfo,
             url: config.webhookUrl,
@@ -333,7 +332,6 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const pullRequests = await this.breaker.runCommand({
             action: 'getAll',
             scopeType: 'pullRequests',
@@ -345,12 +343,10 @@ class GithubScm extends Scm {
             }
         });
 
-        const openedPRs = pullRequests.map(pullRequestInfo => ({
-            name: `PR-${pullRequestInfo.number}`,
-            ref: `pull/${pullRequestInfo.number}/merge`
+        return pullRequests.map(pullRequest => ({
+            name: `PR-${pullRequest.number}`,
+            ref: `pull/${pullRequest.number}/merge`
         }));
-
-        return openedPRs;
     }
 
     /**
@@ -366,7 +362,6 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const repo = await this.breaker.runCommand({
             action: 'get',
             token: config.token,
@@ -397,7 +392,6 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const branch = await this.breaker.runCommand({
             action: 'getBranch',
             token: config.token,
@@ -430,9 +424,7 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const jobName = config.jobName.replace(/^PR-\d+/g, 'PR');
-
         const params = {
             context: `Screwdriver/${config.pipelineId}/${jobName}`,
             description: DESCRIPTION_MAP[config.buildStatus],
@@ -469,7 +461,6 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-
         const file = await this.breaker.runCommand({
             action: 'getContent',
             token: config.token,
@@ -600,7 +591,7 @@ class GithubScm extends Scm {
      * Decorate a given SCM URI with additional data to better display
      * related information. If a branch suffix is not provided, it will default
      * to the master branch
-     * @async _decorateUrl
+     * @async  _decorateUrl
      * @param  {Config}    config        Configuration object
      * @param  {String}    config.scmUri The SCM URI the commit belongs to
      * @param  {String}    config.token  Service token to authenticate with Github
@@ -622,7 +613,7 @@ class GithubScm extends Scm {
 
     /**
      * Check validity of github webhook event signature
-     * @method _checkSignature
+     * @method  _checkSignature
      * @param   {String}    secret      The secret used to sign the payload
      * @param   {String}    payload     The payload of the webhook event
      * @param   {String}    signature   The signature of the webhook event
@@ -801,9 +792,7 @@ class GithubScm extends Scm {
             };
         }
 
-        return {
-            [scmContext]: bellConfig
-        };
+        return { [scmContext]: bellConfig };
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ class GithubScm extends Scm {
      * @param  {Object}     config
      * @param  {Object}     config.scmUri  The SCM URI to look up relevant info
      * @param  {Object}     config.token   Service token to authenticate with Github
-     * @return {Promise}                   Resolves to an object containin repository-related information
+     * @return {Promise}                   Resolves to an object containing repository-related information
      */
     async lookupScmUri(config) {
         const [scmHost, scmId, scmBranch] = config.scmUri.split(':');
@@ -162,8 +162,8 @@ class GithubScm extends Scm {
      * @param  {Object}     config
      * @param  {Object}     config.scmInfo      Data about repo
      * @param  {String}     config.token        Admin token for repo
-     * @param  {Number}     config.page         pagination: page number to search next
-     * @param  {String}     config.url          url for webhook notifications
+     * @param  {Number}     config.page         Pagination: page number to search next
+     * @param  {String}     config.url          Url for webhook notifications
      * @return {Promise}                        Resolves to a list of hooks
      */
     async _findWebhook(config) {
@@ -258,7 +258,7 @@ class GithubScm extends Scm {
     }
 
     /**
-     * Get checkout the source code from a repository
+     * Get the command to check out source code from a repository
      * @async  getCheckoutCommand
      * @param  {Object}    config
      * @param  {String}    config.branch        Pipeline branch

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const Breaker = require('circuit-fuses');
-const Github = require('github');
+const Octokit = require('@octokit/rest');
 const hoek = require('hoek');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
@@ -69,13 +69,13 @@ class GithubScm extends Scm {
     * @param  {Function}    callback             Callback function from github API
     */
     _githubCommand(options, callback) {
-        this.github.authenticate({
+        this.octokit.authenticate({
             type: 'oauth',
             token: options.token
         });
         const scopeType = options.scopeType || 'repos';
 
-        this.github[scopeType][options.action](options.params, callback);
+        this.octokit[scopeType][options.action](options.params, callback);
     }
 
     /**
@@ -118,7 +118,7 @@ class GithubScm extends Scm {
             githubConfig.protocol = this.config.gheProtocol;
             githubConfig.pathPrefix = '/api/v3';
         }
-        this.github = new Github(githubConfig);
+        this.octokit = new Octokit(githubConfig);
 
         // eslint-disable-next-line no-underscore-dangle
         this.breaker = new Breaker(this._githubCommand.bind(this), {

--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ const DESCRIPTION_MAP = {
 };
 
 /**
-* Get repo information
-* @method getInfo
-* @param  {String}  scmUrl      scmUrl of the repo
-* @return {Object}              An object with the user, repo, and branch
-*/
+ * Get repo information
+ * @method getInfo
+ * @param  {String}  scmUrl      scmUrl of the repo
+ * @return {Object}              An object with the user, repo, and branch
+ */
 function getInfo(scmUrl) {
     const matched = (schema.config.regex.CHECKOUT_URL).exec(scmUrl);
 
@@ -59,15 +59,15 @@ function getInfo(scmUrl) {
 
 class GithubScm extends Scm {
     /**
-    * Github command to run
-    * @method _githubCommand
-    * @param  {Object}      options              An object that tells what command & params to run
-    * @param  {String}      options.action       Github method. For example: get
-    * @param  {String}      options.token        Github token used for authentication of requests
-    * @param  {Object}      options.params       Parameters to run with
-    * @param  {String}      [options.scopeType]  Type of request to make. Default is 'repos'
-    * @param  {Function}    callback             Callback function from github API
-    */
+     * Github command to run
+     * @method _githubCommand
+     * @param  {Object}      options              An object that tells what command & params to run
+     * @param  {String}      options.action       Github method. For example: get
+     * @param  {String}      options.token        Github token used for authentication of requests
+     * @param  {Object}      options.params       Parameters to run with
+     * @param  {String}      [options.scopeType]  Type of request to make. Default is 'repos'
+     * @param  {Function}    callback             Callback function from github API
+     */
     _githubCommand(options, callback) {
         this.github.authenticate({
             type: 'oauth',
@@ -79,21 +79,21 @@ class GithubScm extends Scm {
     }
 
     /**
-    * Constructor
-    * @method constructor
-    * @param  {Object}  config                      Configuration config
-    * @param  {Boolean} [config.privateRepo=false]  Request 'repo' scope, which allows read/write access for public & private repos
-    * @param  {String}  [config.gheHost=null]       If using GitHub Enterprise, the host/port of the deployed instance
-    * @param  {String}  [config.gheProtocol=https]  If using GitHub Enterprise, the protocol to use
-    * @param  {String}  [config.username=sd-buildbot]           GitHub username for checkout
-    * @param  {String}  [config.email=dev-null@screwdriver.cd]  GitHub user email for checkout
-    * @param  {Boolean} [config.https=false]        Is the Screwdriver API running over HTTPS
-    * @param  {String}  config.oauthClientId        OAuth Client ID provided by GitHub application
-    * @param  {String}  config.oauthClientSecret    OAuth Client Secret provided by GitHub application
-    * @param  {Object}  [config.fusebox={}]         Circuit Breaker configuration
-    * @param  {String}  config.secret               Secret to validate the signature of webhook events
-    * @return {GithubScm}
-    */
+     * Constructor
+     * @method constructor
+     * @param  {Object}  config                      Configuration object
+     * @param  {Boolean} [config.privateRepo=false]  Request 'repo' scope, which allows read/write access for public & private repos
+     * @param  {String}  [config.gheHost=null]       If using GitHub Enterprise, the host/port of the deployed instance
+     * @param  {String}  [config.gheProtocol=https]  If using GitHub Enterprise, the protocol to use
+     * @param  {String}  [config.username=sd-buildbot]           GitHub username for checkout
+     * @param  {String}  [config.email=dev-null@screwdriver.cd]  GitHub user email for checkout
+     * @param  {Boolean} [config.https=false]        Is the Screwdriver API running over HTTPS
+     * @param  {String}  config.oauthClientId        OAuth Client ID provided by GitHub application
+     * @param  {String}  config.oauthClientSecret    OAuth Client Secret provided by GitHub application
+     * @param  {Object}  [config.fusebox={}]         Circuit Breaker configuration
+     * @param  {String}  config.secret               Secret to validate the signature of webhook events
+     * @return {GithubScm}
+     */
     constructor(config = {}) {
         super();
 
@@ -287,8 +287,8 @@ class GithubScm extends Scm {
             `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +
             `else export SCM_URL=https://${checkoutUrl}; fi`);
         command.push(`${gitWrapper} `
-            + `"git clone --recursive --quiet --progress --branch ${config.branch} `
-            + '$SCM_URL $SD_SOURCE_DIR"');
+                + `"git clone --recursive --quiet --progress --branch ${config.branch} `
+                + '$SCM_URL $SD_SOURCE_DIR"');
         // Reset to SHA
         command.push(`${gitWrapper} "git reset --hard ${checkoutRef} --"`);
         command.push(`echo Reset to ${checkoutRef}`);
@@ -354,13 +354,13 @@ class GithubScm extends Scm {
     }
 
     /**
-    * Get a owners permissions on a repository
-    * @async _getPermissions
-    * @param  {Object}   config            Configuration
-    * @param  {String}   config.scmUri     The scmUri to get permissions on
-    * @param  {String}   config.token      The token used to authenticate to the SCM
-    * @return {Promise}                    Resolves to the repository permissions
-    */
+     * Get a owners permissions on a repository
+     * @async _getPermissions
+     * @param  {Object}   config            Configuration
+     * @param  {String}   config.scmUri     The scmUri to get permissions on
+     * @param  {String}   config.token      The token used to authenticate to the SCM
+     * @return {Promise}                    Resolves to the repository permissions
+     */
     async _getPermissions(config) {
         const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,

--- a/index.js
+++ b/index.js
@@ -66,32 +66,32 @@ class GithubScm extends Scm {
     * @param  {String}      options.token        Github token used for authentication of requests
     * @param  {Object}      options.params       Parameters to run with
     * @param  {String}      [options.scopeType]  Type of request to make. Default is 'repos'
-    * @param  {Function}    callback             Callback function from github API
+    * @return {Promise}                          Resolves to the value returned by octokit
     */
-    _githubCommand(options, callback) {
+    _githubCommand(options) {
         this.octokit.authenticate({
             type: 'oauth',
             token: options.token
         });
         const scopeType = options.scopeType || 'repos';
 
-        this.octokit[scopeType][options.action](options.params, callback);
+        return this.octokit[scopeType][options.action](options.params);
     }
 
     /**
     * Constructor
     * @method constructor
-    * @param  {Object}  options                      Configuration options
-    * @param  {Boolean} [options.privateRepo=false]  Request 'repo' scope, which allows read/write access for public & private repos
-    * @param  {String}  [options.gheHost=null]       If using GitHub Enterprise, the host/port of the deployed instance
-    * @param  {String}  [options.gheProtocol=https]  If using GitHub Enterprise, the protocol to use
-    * @param  {String}  [options.username=sd-buildbot]           GitHub username for checkout
-    * @param  {String}  [options.email=dev-null@screwdriver.cd]  GitHub user email for checkout
-    * @param  {Boolean} [options.https=false]        Is the Screwdriver API running over HTTPS
-    * @param  {String}  options.oauthClientId        OAuth Client ID provided by GitHub application
-    * @param  {String}  options.oauthClientSecret    OAuth Client Secret provided by GitHub application
-    * @param  {Object}  [options.fusebox={}]         Circuit Breaker configuration
-    * @param  {String}  options.secret               Secret to validate the signature of webhook events
+    * @param  {Object}  config                      Configuration config
+    * @param  {Boolean} [config.privateRepo=false]  Request 'repo' scope, which allows read/write access for public & private repos
+    * @param  {String}  [config.gheHost=null]       If using GitHub Enterprise, the host/port of the deployed instance
+    * @param  {String}  [config.gheProtocol=https]  If using GitHub Enterprise, the protocol to use
+    * @param  {String}  [config.username=sd-buildbot]           GitHub username for checkout
+    * @param  {String}  [config.email=dev-null@screwdriver.cd]  GitHub user email for checkout
+    * @param  {Boolean} [config.https=false]        Is the Screwdriver API running over HTTPS
+    * @param  {String}  config.oauthClientId        OAuth Client ID provided by GitHub application
+    * @param  {String}  config.oauthClientSecret    OAuth Client Secret provided by GitHub application
+    * @param  {Object}  [config.fusebox={}]         Circuit Breaker configuration
+    * @param  {String}  config.secret               Secret to validate the signature of webhook events
     * @return {GithubScm}
     */
     constructor(config = {}) {
@@ -111,14 +111,12 @@ class GithubScm extends Scm {
             secret: joi.string().required()
         }).unknown(true), 'Invalid config for GitHub');
 
-        const githubConfig = {};
+        const octokitConfig = {};
 
         if (this.config.gheHost) {
-            githubConfig.host = this.config.gheHost;
-            githubConfig.protocol = this.config.gheProtocol;
-            githubConfig.pathPrefix = '/api/v3';
+            octokitConfig.baseUrl = `${this.config.gheProtocol}://api.${this.config.gheHost}`;
         }
-        this.octokit = new Octokit(githubConfig);
+        this.octokit = new Octokit(octokitConfig);
 
         // eslint-disable-next-line no-underscore-dangle
         this.breaker = new Breaker(this._githubCommand.bind(this), {
@@ -131,44 +129,43 @@ class GithubScm extends Scm {
 
     /**
      * Look up a repo by SCM URI
-     * @method lookupScmUri
-     * @param  {Object}     config Config object
-     * @param  {Object}     config.scmUri The SCM URI to look up relevant info
-     * @param  {Object}     config.token  Service token to authenticate with Github
-     * @return {Promise}                  Resolves to an object containing
-     *                                    repository-related information
+     * @async lookupScmUri
+     * @param  {Object}     config
+     * @param  {Object}     config.scmUri  The SCM URI to look up relevant info
+     * @param  {Object}     config.token   Service token to authenticate with Github
+     * @return {Promise}                   Resolves to an object containin repository-related information
      */
-    lookupScmUri(config) {
+    async lookupScmUri(config) {
         const [scmHost, scmId, scmBranch] = config.scmUri.split(':');
 
-        return this.breaker.runCommand({
+        const data = await this.breaker.runCommand({
             action: 'getById',
             token: config.token,
             params: { id: scmId }
-        }).then((data) => {
-            const [repoOwner, repoName] = data.full_name.split('/');
-
-            return {
-                branch: scmBranch,
-                host: scmHost,
-                repo: repoName,
-                owner: repoOwner
-            };
         });
+
+        const [repoOwner, repoName] = data.full_name.split('/');
+
+        return {
+            branch: scmBranch,
+            host: scmHost,
+            repo: repoName,
+            owner: repoOwner
+        };
     }
 
     /**
      * Look up a webhook from a repo
-     * @method _findWebhook
+     * @async  _findWebhook
      * @param  {Object}     config
      * @param  {Object}     config.scmInfo      Data about repo
      * @param  {String}     config.token        Admin token for repo
      * @param  {Number}     config.page         pagination: page number to search next
      * @param  {String}     config.url          url for webhook notifications
-     * @return {Promise}                        Resolves a list of hooks
+     * @return {Promise}                        Resolves to a list of hooks
      */
-    _findWebhook(config) {
-        return this.breaker.runCommand({
+    async _findWebhook(config) {
+        const hooks = await this.breaker.runCommand({
             action: 'getHooks',
             token: config.token,
             params: {
@@ -177,19 +174,19 @@ class GithubScm extends Scm {
                 page: config.page,
                 per_page: WEBHOOK_PAGE_SIZE
             }
-        }).then((hooks) => {
-            const screwdriverHook = hooks.find(hook =>
-                hoek.reach(hook, 'config.url') === config.url
-            );
-
-            if (!screwdriverHook && hooks.length === WEBHOOK_PAGE_SIZE) {
-                config.page += 1;
-
-                return this._findWebhook(config);
-            }
-
-            return screwdriverHook;
         });
+
+        const screwdriverHook = hooks.find(hook =>
+            hoek.reach(hook, 'config.url') === config.url
+        );
+
+        if (!screwdriverHook && hooks.length === WEBHOOK_PAGE_SIZE) {
+            config.page += 1;
+
+            return this._findWebhook(config);
+        }
+
+        return screwdriverHook;
     }
 
     /**
@@ -198,9 +195,9 @@ class GithubScm extends Scm {
      * @param  {Object}     config
      * @param  {Object}     [config.hookInfo]   Information about a existing webhook
      * @param  {Object}     config.scmInfo      Information about the repo
-     * @param  {String}     config.token        admin token for repo
-     * @param  {String}     config.url          url for webhook notifications
-     * @return {Promise}                        resolves when complete
+     * @param  {String}     config.token        Admin token for repo
+     * @param  {String}     config.url          Payload destination url
+     * @return {Promise}                        Resolves when complete
      */
     _createWebhook(config) {
         let action = 'createHook';
@@ -231,37 +228,37 @@ class GithubScm extends Scm {
 
     /**
      * Adds the Screwdriver webhook to the Github repository
-     * @method _addWebhook
-     * @param  {Object}    config            Config object
-     * @param  {String}    config.scmUri     The SCM URI to add the webhook to
-     * @param  {String}    config.token      Service token to authenticate with Github
-     * @param  {String}    config.webhookUrl The URL to use for the webhook notifications
-     * @return {Promise}                     Resolve means operation completed without failure.
+     * @async  _addWebhook
+     * @param  {Object}    config             Config object
+     * @param  {String}    config.scmUri      The SCM URI to add the webhook to
+     * @param  {String}    config.token       Service token to authenticate with Github
+     * @param  {String}    config.webhookUrl  The URL to use for the webhook notifications
+     * @return {Promise}                      Resolve means operation completed without failure
      */
-    _addWebhook(config) {
-        return this.lookupScmUri({
+    async _addWebhook(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this._findWebhook({
-                scmInfo,
-                url: config.webhookUrl,
-                page: 1,
-                token: config.token
-            }).then(hookInfo =>
-                this._createWebhook({
-                    hookInfo,
-                    scmInfo,
-                    token: config.token,
-                    url: config.webhookUrl
-                })
-            )
-        );
+        });
+
+        const hookInfo = await this._findWebhook({
+            scmInfo,
+            url: config.webhookUrl,
+            page: 1,
+            token: config.token
+        });
+
+        return this._createWebhook({
+            hookInfo,
+            scmInfo,
+            token: config.token,
+            url: config.webhookUrl
+        });
     }
 
     /**
-     * Checkout the source code from a repository; resolves as an object with checkout commands
-     * @method getCheckoutCommand
+     * Get checkout the source code from a repository
+     * @async  getCheckoutCommand
      * @param  {Object}    config
      * @param  {String}    config.branch        Pipeline branch
      * @param  {String}    config.host          Scm host to checkout source code from
@@ -269,9 +266,9 @@ class GithubScm extends Scm {
      * @param  {String}    config.repo          Scm repo name
      * @param  {String}    config.sha           Commit sha
      * @param  {String}    [config.prRef]       PR reference (can be a PR branch or reference)
-     * @return {Promise}
+     * @return {Promise}                        Resolves to object containing name and checkout commands
      */
-    _getCheckoutCommand(config) {
+    async _getCheckoutCommand(config) {
         const checkoutUrl = `${config.host}/${config.org}/${config.repo}`; // URL for https
         const sshCheckoutUrl = `git@${config.host}:${config.org}/${config.repo}`; // URL for ssh
         const checkoutRef = config.prRef ? config.branch : config.sha; // if PR, use pipeline branch
@@ -315,176 +312,185 @@ class GithubScm extends Scm {
             command.push(`export GIT_BRANCH=origin/${config.branch}`);
         }
 
-        return Promise.resolve({
+        return {
             name: 'sd-checkout-code',
             command: command.join(' && ')
-        });
+        };
     }
 
     /**
-     * Get a list of objects which consist of opened PR names and refs
-     * @method _getOpenedPRs
+     * Get a list of names and references of opened PRs
+     * @async  _getOpenedPRs
      * @param  {Object}      config
      * @param  {String}      config.scmUri  The scmUri to get opened PRs from
      * @param  {String}      config.token   The token used to authenticate with the SCM
-     * @return {Promise}
+     * @return {Promise}                    Resolves to an array of objects storing opened PR names and refs
      */
-    _getOpenedPRs(config) {
-        return this.lookupScmUri({
+    async _getOpenedPRs(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'getAll',
-                scopeType: 'pullRequests',
-                token: config.token,
-                params: {
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo,
-                    state: 'open'
-                }
-            })
-        ).then(pullRequests =>
-            pullRequests.map(pullRequestInfo => ({
-                name: `PR-${pullRequestInfo.number}`,
-                ref: `pull/${pullRequestInfo.number}/merge`
-            }))
-        );
+        });
+
+        const pullRequests = await this.breaker.runCommand({
+            action: 'getAll',
+            scopeType: 'pullRequests',
+            token: config.token,
+            params: {
+                owner: scmInfo.owner,
+                repo: scmInfo.repo,
+                state: 'open'
+            }
+        });
+
+        const openedPRs = pullRequests.map(pullRequestInfo => ({
+            name: `PR-${pullRequestInfo.number}`,
+            ref: `pull/${pullRequestInfo.number}/merge`
+        }));
+
+        return openedPRs;
     }
 
     /**
     * Get a owners permissions on a repository
-    * @method _getPermissions
+    * @async _getPermissions
     * @param  {Object}   config            Configuration
     * @param  {String}   config.scmUri     The scmUri to get permissions on
     * @param  {String}   config.token      The token used to authenticate to the SCM
-    * @return {Promise}
+    * @return {Promise}                    Resolves to the repository permissions
     */
-    _getPermissions(config) {
-        return this.lookupScmUri({
+    async _getPermissions(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'get',
-                token: config.token,
-                params: {
-                    repo: scmInfo.repo,
-                    owner: scmInfo.owner
-                }
-            })
-        ).then(data => data.permissions);
+        });
+
+        const repo = await this.breaker.runCommand({
+            action: 'get',
+            token: config.token,
+            params: {
+                repo: scmInfo.repo,
+                owner: scmInfo.owner
+            }
+        });
+
+        return repo.permissions;
     }
 
     /**
      * Get a commit sha for a specific repo#branch or pull request
-     * @method getCommitSha
+     * @async  getCommitSha
      * @param  {Object}   config            Configuration
      * @param  {String}   config.scmUri     The scmUri to get commit sha of
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @param  {Integer}  [config.prNum]    The PR number used to fetch the PR
-     * @return {Promise}
+     * @return {Promise}                    Resolves to the commit SHA
      */
-    _getCommitSha(config) {
+    async _getCommitSha(config) {
         if (config.prNum) {
             return this._getPrInfo(config).then(pr => pr.sha);
         }
 
-        return this.lookupScmUri({
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'getBranch',
-                token: config.token,
-                params: {
-                    branch: scmInfo.branch,
-                    host: scmInfo.host,
-                    repo: scmInfo.repo,
-                    owner: scmInfo.owner
-                }
-            })
-        ).then(data => data.commit.sha);
-    }
+        });
 
-    /**
-    * Update the commit status for a given repo and sha
-    * @method updateCommitStatus
-    * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUri       The scmUri to get permissions on
-    * @param  {String}   config.sha          The sha to apply the status to
-    * @param  {String}   config.buildStatus  The build status used for figuring out the commit status to set
-    * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @param  {String}   config.jobName      Optional name of the job that finished
-    * @param  {String}   config.url          Target url
-    * @param  {Number}   config.pipelineId   Pipeline Id
-    * @return {Promise}
-    */
-    _updateCommitStatus(config) {
-        return this.lookupScmUri({
-            scmUri: config.scmUri,
-            token: config.token
-        }).then((scmInfo) => {
-            const jobName = config.jobName.replace(/^PR-\d+/g, 'PR');
-
-            const params = {
-                context: `Screwdriver/${config.pipelineId}/${jobName}`,
-                description: DESCRIPTION_MAP[config.buildStatus],
+        const branch = await this.breaker.runCommand({
+            action: 'getBranch',
+            token: config.token,
+            params: {
+                branch: scmInfo.branch,
+                host: scmInfo.host,
                 repo: scmInfo.repo,
-                sha: config.sha,
-                state: STATE_MAP[config.buildStatus] || 'failure',
-                owner: scmInfo.owner,
-                target_url: config.url
-            };
-
-            return this.breaker.runCommand({
-                action: 'createStatus',
-                token: config.token,
-                params
-            }).catch((err) => {
-                if (err.code !== 422) {
-                    throw err;
-                }
-            });
-        });
-    }
-
-    /**
-    * Fetch content of a file from github
-    * @method getFile
-    * @param  {Object}   config              Configuration
-    * @param  {String}   config.scmUri       The scmUri to get permissions on
-    * @param  {String}   config.path         The file in the repo to fetch
-    * @param  {String}   config.token        The token used to authenticate to the SCM
-    * @param  {String}   config.ref          The reference to the SCM, either branch or sha
-    * @return {Promise}
-    */
-    _getFile(config) {
-        return this.lookupScmUri(config).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'getContent',
-                token: config.token,
-                params: {
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo,
-                    path: config.path,
-                    ref: config.ref || scmInfo.branch
-                }
-            })
-        ).then((data) => {
-            if (data.type !== 'file') {
-                throw new Error(`Path (${config.path}) does not point to file`);
+                owner: scmInfo.owner
             }
+        });
 
-            return new Buffer(data.content, data.encoding).toString();
+        return branch.commit.sha;
+    }
+
+    /**
+     * Update the commit status for a given repo and sha
+     * @async  updateCommitStatus
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUri       The scmUri to get permissions on
+     * @param  {String}   config.sha          The sha to apply the status to
+     * @param  {String}   config.buildStatus  The build status used for figuring out the commit status to set
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @param  {String}   config.jobName      Optional name of the job that finished
+     * @param  {String}   config.url          Target url
+     * @param  {Number}   config.pipelineId   Pipeline Id
+     * @return {Promise}                      Resolves when operation completed
+     */
+    async _updateCommitStatus(config) {
+        const scmInfo = await this.lookupScmUri({
+            scmUri: config.scmUri,
+            token: config.token
+        });
+
+        const jobName = config.jobName.replace(/^PR-\d+/g, 'PR');
+
+        const params = {
+            context: `Screwdriver/${config.pipelineId}/${jobName}`,
+            description: DESCRIPTION_MAP[config.buildStatus],
+            repo: scmInfo.repo,
+            sha: config.sha,
+            state: STATE_MAP[config.buildStatus] || 'failure',
+            owner: scmInfo.owner,
+            target_url: config.url
+        };
+
+        return this.breaker.runCommand({
+            action: 'createStatus',
+            token: config.token,
+            params
+        }).catch((err) => {
+            if (err.code !== 422) {
+                throw err;
+            }
         });
     }
 
     /**
-    * Retrieve stats for the executor
-    * @method stats
-    * @param  {Response} Object          Object containing stats for the executor
-    */
+     * Fetch content of a file from github
+     * @async getFile
+     * @param  {Object}   config              Configuration
+     * @param  {String}   config.scmUri       The scmUri to get permissions on
+     * @param  {String}   config.path         The file in the repo to fetch
+     * @param  {String}   config.token        The token used to authenticate to the SCM
+     * @param  {String}   config.ref          The reference to the SCM, either branch or sha
+     * @return {Promise}                      Resolves to string containing contents of file
+     */
+    async _getFile(config) {
+        const scmInfo = await this.lookupScmUri({
+            scmUri: config.scmUri,
+            token: config.token
+        });
+
+        const file = await this.breaker.runCommand({
+            action: 'getContent',
+            token: config.token,
+            params: {
+                owner: scmInfo.owner,
+                repo: scmInfo.repo,
+                path: config.path,
+                ref: config.ref || scmInfo.branch
+            }
+        });
+
+        if (file.type !== 'file') {
+            throw new Error(`Path (${config.path}) does not point to file`);
+        }
+
+        return new Buffer(file.content, file.encoding).toString();
+    }
+
+    /**
+     * Retrieve stats for the executor
+     * @method stats
+     * @param  {Response} Object          Object containing stats for the executor
+     */
     stats() {
         const stats = this.breaker.stats();
         const scmContexts = this._getScmContexts();
@@ -497,123 +503,119 @@ class GithubScm extends Scm {
 
     /**
      * Get id of a specific repo
-     * @method _getRepoId
+     * @async  _getRepoId
      * @param  {Object}   scmInfo               The result of getScmInfo
      * @param  {String}   token                 The token used to authenticate to the SCM
      * @param  {String}   config.checkoutUrl    The checkoutUrl to parse
-     * @return {Promise}                        Resolves to the result object of GitHub repository API
+     * @return {Promise}                        Resolves to the id of the repo
      */
-    _getRepoId(scmInfo, token, checkoutUrl) {
-        return this.breaker.runCommand({
-            action: 'get',
-            token,
-            params: scmInfo })
-            .then(data => data.id)
-            .catch((err) => {
-                if (err.code === 404) {
-                    throw new Error(`Cannot find repository ${checkoutUrl}`);
-                }
-
-                throw new Error(err);
+    async _getRepoId(scmInfo, token, checkoutUrl) {
+        try {
+            const repo = await this.breaker.runCommand({
+                action: 'get',
+                token,
+                params: scmInfo
             });
+
+            return repo.id;
+        } catch (err) {
+            if (err.code === 404) {
+                throw new Error(`Cannot find repository ${checkoutUrl}`);
+            }
+
+            throw new Error(err);
+        }
     }
 
     /**
      * Decorate the author based on the Github service
-     * @method _decorateAuthor
+     * @async  _decorateAuthor
      * @param  {Object}        config          Configuration object
      * @param  {Object}        config.token    Service token to authenticate with Github
      * @param  {Object}        config.username Username to query more information for
-     * @return {Promise}
+     * @return {Promise}                       Resolves to decorated user object
      */
-    _decorateAuthor(config) {
-        return this.breaker.runCommand({
+    async _decorateAuthor(config) {
+        const user = await this.breaker.runCommand({
             action: 'getForUser',
             scopeType: 'users',
             token: config.token,
             params: { username: config.username }
-        }).then((data) => {
-            const name = data.name ? data.name : data.login;
-
-            return {
-                avatar: data.avatar_url,
-                name,
-                username: data.login,
-                url: data.html_url
-            };
         });
+        const name = user.name ? user.name : user.login;
+
+        return {
+            avatar: user.avatar_url,
+            name,
+            username: user.login,
+            url: user.html_url
+        };
     }
 
     /**
      * Decorate the commit based on the repository
-     * @method _decorateCommit
+     * @async  _decorateCommit
      * @param  {Object}        config        Configuration object
      * @param  {Object}        config.scmUri SCM URI the commit belongs to
      * @param  {Object}        config.sha    SHA to decorate data with
      * @param  {Object}        config.token  Service token to authenticate with Github
-     * @return {Promise}
+     * @return {Promise}                     Resolves to decorated commit object
      */
-    _decorateCommit(config) {
-        const commitLookup = this.lookupScmUri({
+    async _decorateCommit(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'getCommit',
-                token: config.token,
-                params: {
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo,
-                    sha: config.sha
-                }
-            })
-        );
-        const authorLookup = commitLookup.then((commitData) => {
-            if (!commitData.author) {
-                return DEFAULT_AUTHOR;
+        });
+        const commit = await this.breaker.runCommand({
+            action: 'getCommit',
+            token: config.token,
+            params: {
+                owner: scmInfo.owner,
+                repo: scmInfo.repo,
+                sha: config.sha
             }
-
-            return this.decorateAuthor({
-                token: config.token,
-                username: commitData.author.login
-            });
         });
 
-        return Promise.all([
-            commitLookup,
-            authorLookup
-        ]).then(([commitData, authorData]) =>
-            ({
-                author: authorData,
-                message: commitData.commit.message,
-                url: commitData.html_url
-            })
-        );
+        let author;
+
+        if (!commit.author) {
+            author = DEFAULT_AUTHOR;
+        } else {
+            author = await this.decorateAuthor({
+                token: config.token,
+                username: commit.author.login
+            });
+        }
+
+        return {
+            author,
+            message: commit.commit.message,
+            url: commit.html_url
+        };
     }
 
     /**
      * Decorate a given SCM URI with additional data to better display
      * related information. If a branch suffix is not provided, it will default
      * to the master branch
-     * @method _decorateUrl
+     * @async _decorateUrl
      * @param  {Config}    config        Configuration object
      * @param  {String}    config.scmUri The SCM URI the commit belongs to
      * @param  {String}    config.token  Service token to authenticate with Github
-     * @return {Promise}
+     * @return {Promise}                 Resolves to decorated url object
      */
-    _decorateUrl(config) {
-        return this.lookupScmUri({
+    async _decorateUrl(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then((scmInfo) => {
-            const baseUrl = `${scmInfo.host}/${scmInfo.owner}/${scmInfo.repo}`;
-
-            return {
-                branch: scmInfo.branch,
-                name: `${scmInfo.owner}/${scmInfo.repo}`,
-                url: `https://${baseUrl}/tree/${scmInfo.branch}`
-            };
         });
+        const baseUrl = `${scmInfo.host}/${scmInfo.owner}/${scmInfo.repo}`;
+
+        return {
+            branch: scmInfo.branch,
+            name: `${scmInfo.owner}/${scmInfo.repo}`,
+            url: `https://${baseUrl}/tree/${scmInfo.branch}`
+        };
     }
 
     /**
@@ -639,17 +641,16 @@ class GithubScm extends Scm {
 
     /**
      * Get the changed files from a Git event
-     * @method _getChangedFiles
-     * @param  {Object}   config                 Configuration object
-     * @param  {String}   config.type            Can be 'pr' or 'repo'
-     * @param  {Object}   config.webhookPayload  The webhook payload received from the
-     *                                           SCM service.
-     * @param  {String}   config.token           Service token to authenticate with Github
-     * @return {Promise}
+     * @async  _getChangedFiles
+     * @param  {Object}   config           Configuration object
+     * @param  {String}   config.type      Can be 'pr' or 'repo'
+     * @param  {Object}   config.payload   The webhook payload received from the SCM service.
+     * @param  {String}   config.token     Service token to authenticate with Github
+     * @return {Promise}                   Resolves to an array of filenames of the changed files
      */
-    _getChangedFiles({ type, payload, token }) {
+    async _getChangedFiles({ type, payload, token }) {
         if (type === 'pr') {
-            return this.breaker.runCommand({
+            const files = await this.breaker.runCommand({
                 action: 'getFiles',
                 scopeType: 'pullRequests',
                 token,
@@ -658,16 +659,11 @@ class GithubScm extends Scm {
                     repo: hoek.reach(payload, 'repository.name'),
                     number: hoek.reach(payload, 'number')
                 }
-            }).then((data) => {
-                const fileNames = [];
-
-                data.forEach((file) => {
-                    fileNames.push(file.filename);
-                });
-
-                return fileNames;
             });
+
+            return files.map(file => file.filename);
         }
+
         if (type === 'repo') {
             return hoek.reach(payload, 'head_commit.modified');
         }
@@ -678,7 +674,7 @@ class GithubScm extends Scm {
     /**
      * Given a SCM webhook payload & its associated headers, aggregate the
      * necessary data to execute a Screwdriver job with.
-     * @method _parseHook
+     * @async  _parseHook
      * @param  {Object}  payloadHeaders  The request headers associated with the
      *                                   webhook payload
      * @param  {Object}  webhookPayload  The webhook payload received from the
@@ -686,12 +682,12 @@ class GithubScm extends Scm {
      * @return {Promise}                 A key-map of data related to the received
      *                                   payload
      */
-    _parseHook(payloadHeaders, webhookPayload) {
+    async _parseHook(payloadHeaders, webhookPayload) {
         const signature = payloadHeaders['x-hub-signature'];
 
         // eslint-disable-next-line no-underscore-dangle
         if (!this._checkSignature(this.config.secret, webhookPayload, signature)) {
-            return Promise.reject('Invalid x-hub-signature');
+            throw new Error('Invalid x-hub-signature');
         }
 
         const type = payloadHeaders['x-github-event'];
@@ -711,14 +707,14 @@ class GithubScm extends Scm {
             // "opened", "closed", "reopened", "synchronize",
             // "assigned", "unassigned", "labeled", "unlabeled", "edited"
             if (!['opened', 'reopened', 'synchronize', 'closed'].includes(action)) {
-                return Promise.resolve(null);
+                return null;
             }
 
             if (action === 'synchronize') {
                 action = 'synchronized';
             }
 
-            return Promise.resolve({
+            return {
                 action,
                 branch: hoek.reach(webhookPayload, 'pull_request.base.ref'),
                 checkoutUrl,
@@ -730,10 +726,10 @@ class GithubScm extends Scm {
                 username: hoek.reach(webhookPayload, 'sender.login'),
                 hookId,
                 scmContext: scmContexts[0]
-            });
+            };
         }
         case 'push':
-            return Promise.resolve({
+            return {
                 action: 'push',
                 branch: hoek.reach(webhookPayload, 'ref').replace(/^refs\/heads\//, ''),
                 checkoutUrl,
@@ -743,9 +739,9 @@ class GithubScm extends Scm {
                 lastCommitMessage: hoek.reach(webhookPayload, 'head_commit.message') || '',
                 hookId,
                 scmContext: scmContexts[0]
-            });
+            };
         default:
-            return Promise.resolve(null);
+            return null;
         }
     }
 
@@ -754,36 +750,33 @@ class GithubScm extends Scm {
      *
      * 'token' is required, since it is necessary to lookup the SCM ID by
      * communicating with said SCM service.
-     * @method _parseUrl
+     * @async  _parseUrl
      * @param  {Object}     config              Config object
      * @param  {String}     config.checkoutUrl  The checkoutUrl to parse
      * @param  {String}     config.token        The token used to authenticate to the SCM service
      * @return {Promise}                        Resolves to an ID of 'serviceName:repoId:branchName'
      */
-    _parseUrl(config) {
-        return new Promise((resolve) => {
-            resolve(getInfo(config.checkoutUrl));
-        }).then((scmInfo) => {
-            const myHost = this.config.gheHost || 'github.com';
+    async _parseUrl(config) {
+        const scmInfo = getInfo(config.checkoutUrl);
+        const myHost = this.config.gheHost || 'github.com';
 
-            if (scmInfo.host !== myHost) {
-                const message = 'This checkoutUrl is not supported for your current login host.';
+        if (scmInfo.host !== myHost) {
+            const message = 'This checkoutUrl is not supported for your current login host.';
 
-                return Promise.reject(new Error(message));
-            }
+            throw new Error(message);
+        }
 
-            // eslint-disable-next-line no-underscore-dangle
-            return this._getRepoId(scmInfo, config.token, config.checkoutUrl)
-                .then(repoId => `${scmInfo.host}:${repoId}:${scmInfo.branch}`);
-        });
+        const repoId = await this._getRepoId(scmInfo, config.token, config.checkoutUrl);
+
+        return `${scmInfo.host}:${repoId}:${scmInfo.branch}`;
     }
 
     /**
      * Return a valid Bell configuration (for OAuth)
-     * @method _getBellConfiguration
+     * @async  _getBellConfiguration
      * @return {Promise}
      */
-    _getBellConfiguration() {
+    async _getBellConfiguration() {
         const scmContexts = this._getScmContexts();
         const scmContext = scmContexts[0];
         const scope = ['admin:repo_hook', 'read:org', 'repo:status'];
@@ -806,40 +799,41 @@ class GithubScm extends Scm {
             };
         }
 
-        return Promise.resolve({
+        return {
             [scmContext]: bellConfig
-        });
+        };
     }
 
     /**
      * Resolve a pull request object based on the config
-     * @method getPrRef
+     * @async  getPrRef
      * @param  {Object}   config            Configuration
      * @param  {String}   config.scmUri     The scmUri to get PR info of
      * @param  {String}   config.token      The token used to authenticate to the SCM
      * @param  {Integer}  config.prNum      The PR number used to fetch the PR
      * @return {Promise}
      */
-    _getPrInfo(config) {
-        return this.lookupScmUri({
+    async _getPrInfo(config) {
+        const scmInfo = await this.lookupScmUri({
             scmUri: config.scmUri,
             token: config.token
-        }).then(scmInfo =>
-            this.breaker.runCommand({
-                action: 'get',
-                scopeType: 'pullRequests',
-                token: config.token,
-                params: {
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo,
-                    number: config.prNum
-                }
-            })
-        ).then(pullRequestInfo => ({
+        });
+        const pullRequestInfo = await this.breaker.runCommand({
+            action: 'get',
+            scopeType: 'pullRequests',
+            token: config.token,
+            params: {
+                owner: scmInfo.owner,
+                repo: scmInfo.repo,
+                number: config.prNum
+            }
+        });
+
+        return {
             name: `PR-${pullRequestInfo.number}`,
             ref: `pull/${pullRequestInfo.number}/merge`,
             sha: pullRequestInfo.head.sha
-        }));
+        };
     }
 
     /**
@@ -857,25 +851,26 @@ class GithubScm extends Scm {
 
     /**
      * Determine if a scm module can handle the received webhook
-     * @method canHandleWebhook
-     * @param {Object}    headers    The request headers associated with the webhook payload
-     * @param {Object}    payload    The webhook payload received from the SCM service
-     * @return {Promise}
+     * @async  canHandleWebhook
+     * @param  {Object}    headers    The request headers associated with the webhook payload
+     * @param  {Object}    payload    The webhook payload received from the SCM service
+     * @return {Promise}              Resolves a boolean denoting whether scm module supports webhook
      */
-    _canHandleWebhook(headers, payload) {
-        return this._parseHook(headers, payload)
-            .then((result) => {
-                if (result === null) {
-                    return false;
-                }
-                const checkoutSshHost = this.config.gheHost
-                    ? `git@${this.config.gheHost}:`
-                    : 'git@github.com:';
+    async _canHandleWebhook(headers, payload) {
+        try {
+            const result = await this._parseHook(headers, payload);
+            const checkoutSshHost = this.config.gheHost
+                ? `git@${this.config.gheHost}:`
+                : 'git@github.com:';
 
-                return result.checkoutUrl.startsWith(checkoutSshHost);
-            }).catch(() => (
-                Promise.resolve(false)
-            ));
+            if (result === null) {
+                return false;
+            }
+
+            return result.checkoutUrl.startsWith(checkoutSshHost);
+        } catch (err) {
+            return false;
+        }
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ class GithubScm extends Scm {
 
     /**
      * Look up a repo by SCM URI
-     * @async lookupScmUri
+     * @async  lookupScmUri
      * @param  {Object}     config
      * @param  {Object}     config.scmUri  The SCM URI to look up relevant info
      * @param  {Object}     config.token   Service token to authenticate with Github
@@ -198,7 +198,7 @@ class GithubScm extends Scm {
      * @param  {Object}     [config.hookInfo]   Information about a existing webhook
      * @param  {Object}     config.scmInfo      Information about the repo
      * @param  {String}     config.token        Admin token for repo
-     * @param  {String}     config.url          Payload destination url
+     * @param  {String}     config.url          Payload destination url for webhook notifications
      * @return {Promise}                        Resolves when complete
      */
     _createWebhook(config) {
@@ -351,7 +351,7 @@ class GithubScm extends Scm {
 
     /**
      * Get a owners permissions on a repository
-     * @async _getPermissions
+     * @async  _getPermissions
      * @param  {Object}   config            Configuration
      * @param  {String}   config.scmUri     The scmUri to get permissions on
      * @param  {String}   config.token      The token used to authenticate to the SCM
@@ -448,7 +448,7 @@ class GithubScm extends Scm {
 
     /**
      * Fetch content of a file from github
-     * @async getFile
+     * @async  getFile
      * @param  {Object}   config              Configuration
      * @param  {String}   config.scmUri       The scmUri to get permissions on
      * @param  {String}   config.path         The file in the repo to fetch

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "Min Zhang <minzhang@andrew.cmu.edu>",
     "Noah Katzman <nbkatzman@gmail.com>",
     "Peter Peterson <jedipetey@gmail.com>",
+    "Philip Scott <pscott@zeptohost.com>",
     "St. John Johnson <st.john.johnson@gmail.com",
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
@@ -40,7 +41,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
-    "github": "^8.1.1",
+    "@octokit/rest": "^15.2.6",
     "hoek": "^5.0.3",
     "joi": "^13.0.0",
     "screwdriver-data-schema": "^18.13.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "circuit-fuses": "^2.0.3",
-    "@octokit/rest": "^15.2.6",
+    "github": "^8.1.1",
     "hoek": "^5.0.3",
     "joi": "^13.0.0",
     "screwdriver-data-schema": "^18.13.0",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:
@@ -10,7 +10,7 @@ jobs:
 
     publish:
         requires: [main]
-        template: screwdriver-cd/semantic-release 
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -959,7 +959,7 @@ jobs:
                     assert.fail('This should not fail the tests');
                 })
                 .catch((err) => {
-                    assert.equal(err, 'Invalid x-hub-signature');
+                    assert.equal(err.message, 'Invalid x-hub-signature');
                 });
         });
     });


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it. Aside from maintenance, upgrading to Node.js 8 also provides async functions, which simplify `Promise` control flow.

## Objective

* Change image in `screwdriver.yaml` to `node:8`
* Convert functions that return a `Promise` to `async` functions

#### Additional changes

* Bump up coverage to 100%
* Remove empty `test.js` file