### PR TITLE
fix(911): Also check added and removed files for sourcePaths

### DIFF
--- a/index.js
+++ b/index.js
@@ -669,7 +669,12 @@ class GithubScm extends Scm {
             });
         }
         if (type === 'repo') {
-            return hoek.reach(payload, 'head_commit.modified');
+            const added = hoek.reach(payload, 'head_commit.added');
+            const modified = hoek.reach(payload, 'head_commit.modified');
+            const removed = hoek.reach(payload, 'head_commit.removed');
+
+            // Adding the arrays together and pruning duplicates
+            return [...new Set([...added, ...modified, ...removed])];
         }
 
         return [];

--- a/test/data/github.push.json
+++ b/test/data/github.push.json
@@ -26,13 +26,14 @@
         "username": "baxterthehacker"
       },
       "added": [
-
+        "README.md"
       ],
       "removed": [
-
+        "screwdriver.yaml"
       ],
       "modified": [
-        "README.md"
+        "README.md",
+        "package.json"
       ]
     }
   ],
@@ -54,13 +55,14 @@
       "username": "baxterthehacker"
     },
     "added": [
-
+      "README.md"
     ],
     "removed": [
-
+      "screwdriver.yaml"
     ],
     "modified": [
-      "README.md"
+      "README.md",
+      "package.json"
     ]
   },
   "repository": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -793,7 +793,11 @@ jobs:
                 payload: testPayloadPush
             })
                 .then((result) => {
-                    assert.deepEqual(result, ['README.md']);
+                    assert.deepEqual(result, [
+                        'README.md',
+                        'package.json',
+                        'screwdriver.yaml'
+                    ]);
                 });
         });
 
@@ -867,7 +871,7 @@ jobs:
             };
 
             testHeaders = {
-                'x-hub-signature': 'sha1=a72eab99ad7f36f582f224df8d735091b06f1802',
+                'x-hub-signature': 'sha1=28b327e936e52b6ffb6014d3e1d7372a74d82992',
                 'x-github-event': 'pull_request',
                 'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
             };
@@ -1695,7 +1699,7 @@ jobs:
 
         beforeEach(() => {
             testHeaders = {
-                'x-hub-signature': 'sha1=a72eab99ad7f36f582f224df8d735091b06f1802',
+                'x-hub-signature': 'sha1=28b327e936e52b6ffb6014d3e1d7372a74d82992',
                 'x-github-event': 'pull_request',
                 'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
             };


### PR DESCRIPTION
## Context
There's also `added` and `removed` files that might be changes for a push event in Github.

## Objective
This PR adds those files to `getChangedFiles` results.

## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911