### PR TITLE
feat(1042): Update github module to @octokit/rest. BREAKING CHANGE: updating major versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,14 +249,13 @@ class GithubScm extends Scm {
             page: 1,
             token: config.token
         });
-        const hook = await this._createWebhook({
+
+        return this._createWebhook({
             hookInfo,
             scmInfo,
             token: config.token,
             url: config.webhookUrl
         });
-
-        return hook;
     }
 
     /**
@@ -518,17 +517,21 @@ class GithubScm extends Scm {
             target_url: config.url
         };
 
-        const status = await this.breaker.runCommand({
-            action: 'createStatus',
-            token: config.token,
-            params
-        }).catch((err) => {
+        try {
+            const status = await this.breaker.runCommand({
+                action: 'createStatus',
+                token: config.token,
+                params
+            });
+
+            return status ? status.data : undefined;
+        } catch (err) {
             if (err.code !== 422) {
                 throw err;
             }
-        });
 
-        return status ? status.data : undefined;
+            return undefined;
+        }
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
+    "@octokit/rest": "^15.9.4",
     "circuit-fuses": "^2.0.3",
-    "github": "^8.1.1",
     "hoek": "^5.0.3",
     "joi": "^13.4.0",
-    "screwdriver-data-schema": "^18.25.0",
+    "screwdriver-data-schema": "^18.29.1",
     "screwdriver-scm-base": "^4.2.0"
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "circuit-fuses": "^2.0.3",
     "hoek": "^5.0.3",
     "joi": "^13.4.0",
-    "screwdriver-data-schema": "^18.29.1",
+    "screwdriver-data-schema": "^18.29.2",
     "screwdriver-scm-base": "^4.2.0"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,7 +65,7 @@ describe('index', function () {
         };
         githubMockClass = sinon.stub().returns(githubMock);
 
-        mockery.registerMock('github', githubMockClass);
+        mockery.registerMock('@octokit/rest', githubMockClass);
 
         // eslint-disable-next-line global-require
         GithubScm = require('../');
@@ -117,7 +117,7 @@ describe('index', function () {
             assert.calledWith(githubMockClass, {});
         });
 
-        it('can configure for GHE', () => {
+        it('can configure for Github Enterprise', () => {
             scm = new GithubScm({
                 gheHost: 'github.screwdriver.cd',
                 oauthClientId: 'abcdefg',
@@ -125,9 +125,7 @@ describe('index', function () {
                 secret: 'somesecret'
             });
             assert.calledWith(githubMockClass, {
-                host: 'github.screwdriver.cd',
-                protocol: 'https',
-                pathPrefix: '/api/v3'
+                baseUrl: 'https://github.screwdriver.cd/api/v3'
             });
         });
     });
@@ -225,10 +223,10 @@ describe('index', function () {
         };
 
         it('promises to get the commit sha without prNum', () => {
-            githubMock.repos.getBranch.yieldsAsync(null, branch);
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getBranch.yieldsAsync(null, { data: branch });
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
+            } });
 
             return scm.getCommitSha(config)
                 .then((data) => {
@@ -237,7 +235,6 @@ describe('index', function () {
                     assert.calledWith(githubMock.repos.getBranch, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
-                        host: 'github.com',
                         branch: 'master'
                     });
                     assert.calledWith(githubMock.repos.getById, {
@@ -252,11 +249,11 @@ describe('index', function () {
 
         it('promises to get the commit sha with prNum', () => {
             config.prNum = 1;
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
+            } });
             githubMock.pullRequests.get.yieldsAsync(null,
-                { number: config.prNum, head: { sha: branch.commit.sha } }
+                { data: { number: config.prNum, head: { sha: branch.commit.sha } } }
             );
 
             return scm.getCommitSha(config)
@@ -302,9 +299,9 @@ describe('index', function () {
         it('fails when unable to get the branch info from a repo', () => {
             const error = new Error('githubBreaking');
 
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
+            } });
             githubMock.repos.getBranch.yieldsAsync(error);
 
             return scm.getCommitSha(config).then(() => {
@@ -315,7 +312,6 @@ describe('index', function () {
                 assert.calledWith(githubMock.repos.getBranch, {
                     owner: 'screwdriver-cd',
                     repo: 'models',
-                    host: 'github.com',
                     branch: 'master'
                 });
 
@@ -346,13 +342,13 @@ describe('index', function () {
         };
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
+            } });
         });
 
         it('promises to get permissions', () => {
-            githubMock.repos.get.yieldsAsync(null, repo);
+            githubMock.repos.get.yieldsAsync(null, { data: repo });
 
             return scm.getPermissions(config)
                 .then((data) => {
@@ -406,7 +402,7 @@ describe('index', function () {
                 full_name: 'screwdriver-cd/models'
             };
 
-            githubMock.repos.getById.yieldsAsync(null, testResponse);
+            githubMock.repos.getById.yieldsAsync(null, { data: testResponse });
 
             return scm.lookupScmUri({
                 scmUri,
@@ -475,10 +471,10 @@ describe('index', function () {
                 pipelineId: 675
             };
 
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
-            githubMock.repos.createStatus.yieldsAsync(null, data);
+            } });
+            githubMock.repos.createStatus.yieldsAsync(null, { data });
         });
 
         it('promises to update commit status on success', () =>
@@ -568,7 +564,7 @@ describe('index', function () {
                 });
         });
 
-        it('catches and discards github command errors when it has a 422 error code', () => {
+        it('catches and discards Github errors when it has a 422 error code', () => {
             const errMsg = JSON.stringify({
                 message: 'Validation Failed',
                 errors: [
@@ -591,7 +587,6 @@ describe('index', function () {
             return scm.updateCommitStatus(config)
                 .then((result) => {
                     assert.deepEqual(result, undefined);
-
                     assert.calledWith(githubMock.repos.createStatus, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
@@ -652,10 +647,10 @@ describe('index', function () {
                 jobName: 'main'
             };
 
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
-            githubMock.repos.createStatus.yieldsAsync(null, {});
+            } });
+            githubMock.repos.createStatus.yieldsAsync(null, { data: {} });
 
             return scm.updateCommitStatus(config)
                 .then(() => {
@@ -721,13 +716,13 @@ jobs:
         };
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'screwdriver-cd/models'
-            });
+            } });
         });
 
         it('promises to get content when a ref is passed', () => {
-            githubMock.repos.getContent.yieldsAsync(null, returnData);
+            githubMock.repos.getContent.yieldsAsync(null, { data: returnData });
 
             return scm.getFile(config)
                 .then((data) => {
@@ -747,7 +742,7 @@ jobs:
         });
 
         it('promises to get content when a ref is not passed', () => {
-            githubMock.repos.getContent.yieldsAsync(null, returnData);
+            githubMock.repos.getContent.yieldsAsync(null, { data: returnData });
 
             return scm.getFile(configNoRef)
                 .then((data) => {
@@ -770,7 +765,7 @@ jobs:
         it('returns error when path is not a file', () => {
             const expectedErrorMessage = 'Path (screwdriver.yaml) does not point to file';
 
-            githubMock.repos.getContent.yieldsAsync(null, returnInvalidData);
+            githubMock.repos.getContent.yieldsAsync(null, { data: returnInvalidData });
 
             return scm.getFile(config)
                 .then(() => {
@@ -844,7 +839,7 @@ jobs:
         });
 
         it('returns changed files for a pull request event payload', () => {
-            githubMock.pullRequests.getFiles.yieldsAsync(null, testPrFiles);
+            githubMock.pullRequests.getFiles.yieldsAsync(null, { data: testPrFiles });
             type = 'pr';
 
             return scm.getChangedFiles({
@@ -1029,7 +1024,7 @@ jobs:
         });
 
         it('parses a complete ssh url', () => {
-            githubMock.repos.get.yieldsAsync(null, repoData);
+            githubMock.repos.get.yieldsAsync(null, { data: repoData });
 
             return scm.parseUrl({
                 checkoutUrl,
@@ -1047,7 +1042,7 @@ jobs:
         it('parses a ssh url, defaulting the branch to master', () => {
             checkoutUrl = 'git@github.com:iAm/theCaptain.git';
 
-            githubMock.repos.get.yieldsAsync(null, repoData);
+            githubMock.repos.get.yieldsAsync(null, { data: repoData });
 
             return scm.parseUrl({
                 checkoutUrl,
@@ -1133,13 +1128,13 @@ jobs:
         const username = 'notmrkent';
 
         it('decorates a github user', () => {
-            githubMock.users.getForUser.yieldsAsync(null, {
+            githubMock.users.getForUser.yieldsAsync(null, { data: {
                 login: username,
                 id: 2042,
                 avatar_url: 'https://avatars.githubusercontent.com/u/2042?v=3',
                 html_url: `https://github.com/${username}`,
                 name: 'Klark Cent'
-            });
+            } });
 
             return scm.decorateAuthor({
                 token: 'tokenfordecorateauthor',
@@ -1159,13 +1154,13 @@ jobs:
         });
 
         it('defaults to username when display name does not exist', () => {
-            githubMock.users.getForUser.yieldsAsync(null, {
+            githubMock.users.getForUser.yieldsAsync(null, { data: {
                 login: username,
                 id: 2042,
                 avatar_url: 'https://avatars.githubusercontent.com/u/2042?v=3',
                 html_url: `https://github.com/${username}`,
                 name: null
-            });
+            } });
 
             return scm.decorateAuthor({
                 token: 'tokenfordecorateauthor',
@@ -1213,21 +1208,21 @@ jobs:
         const username = 'notbrucewayne';
 
         beforeEach(() => {
-            githubMock.users.getForUser.yieldsAsync(null, {
+            githubMock.users.getForUser.yieldsAsync(null, { data: {
                 login: username,
                 id: 1234567,
                 avatar_url: 'https://avatars.githubusercontent.com/u/1234567?v=3',
                 html_url: `https://internal-ghe.mycompany.com/${username}`,
                 name: 'Batman Wayne'
-            });
+            } });
 
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: `${repoOwner}/${repoName}`
-            });
+            } });
         });
 
         it('decorates a commit', () => {
-            githubMock.repos.getCommit.yieldsAsync(null, {
+            githubMock.repos.getCommit.yieldsAsync(null, { data: {
                 commit: {
                     message: 'some commit message that is here'
                 },
@@ -1235,7 +1230,7 @@ jobs:
                     login: username
                 },
                 html_url: 'https://link.to/commitDiff'
-            });
+            } });
 
             return scm.decorateCommit({
                 scmUri,
@@ -1268,13 +1263,13 @@ jobs:
         });
 
         it('defaults author data to empty if author is missing', () => {
-            githubMock.repos.getCommit.yieldsAsync(null, {
+            githubMock.repos.getCommit.yieldsAsync(null, { data: {
                 commit: {
                     message: 'some commit message that is here'
                 },
                 author: null,
                 html_url: 'https://link.to/commitDiff'
-            });
+            } });
             githubMock.users.getForUser.yieldsAsync();
 
             return scm.decorateCommit({
@@ -1332,9 +1327,9 @@ jobs:
         it('decorates a scm uri', () => {
             const scmUri = 'github.com:102498:boat';
 
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'iAm/theCaptain'
-            });
+            } });
 
             return scm.decorateUrl({
                 scmUri,
@@ -1465,18 +1460,18 @@ jobs:
         };
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'dolores/violentdelights'
-            });
-            githubMock.repos.getHooks.yieldsAsync(null, [{
+            } });
+            githubMock.repos.getHooks.yieldsAsync(null, { data: [{
                 config: { url: 'https://somewhere.in/the/interwebs' },
                 id: 783150
-            }]);
+            }] });
         });
 
         it('add a hook', () => {
-            githubMock.repos.getHooks.yieldsAsync(null, []);
-            githubMock.repos.createHook.yieldsAsync(null);
+            githubMock.repos.getHooks.yieldsAsync(null, { data: [] });
+            githubMock.repos.createHook.yieldsAsync(null, { data: [] });
 
             return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.authenticate, sinon.match({
@@ -1501,7 +1496,7 @@ jobs:
         });
 
         it('updates a pre-existing hook', () => {
-            githubMock.repos.editHook.yieldsAsync(null);
+            githubMock.repos.editHook.yieldsAsync(null, { data: [] });
 
             return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.repos.getHooks, {
@@ -1518,7 +1513,7 @@ jobs:
                         url: 'https://somewhere.in/the/interwebs'
                     },
                     events: ['push', 'pull_request'],
-                    id: 783150,
+                    hook_id: 783150,
                     name: 'web',
                     owner: 'dolores',
                     repo: 'violentdelights'
@@ -1533,8 +1528,8 @@ jobs:
                 invalidHooks.push({});
             }
 
-            githubMock.repos.getHooks.onCall(0).yieldsAsync(null, invalidHooks);
-            githubMock.repos.editHook.yieldsAsync(null);
+            githubMock.repos.getHooks.onCall(0).yieldsAsync(null, { data: invalidHooks });
+            githubMock.repos.editHook.yieldsAsync(null, { data: [] });
 
             return scm.addWebhook(webhookConfig).then(() => {
                 assert.calledWith(githubMock.repos.getHooks, {
@@ -1551,7 +1546,7 @@ jobs:
                         url: 'https://somewhere.in/the/interwebs'
                     },
                     events: ['push', 'pull_request'],
-                    id: 783150,
+                    hook_id: 783150,
                     name: 'web',
                     owner: 'dolores',
                     repo: 'violentdelights'
@@ -1572,7 +1567,7 @@ jobs:
         it('throws an error when failing to createHook', () => {
             const testError = new Error('createHookError');
 
-            githubMock.repos.getHooks.yieldsAsync(null, []);
+            githubMock.repos.getHooks.yieldsAsync(null, { data: [] });
             githubMock.repos.createHook.yieldsAsync(testError);
 
             return scm.addWebhook(webhookConfig).then(assert.fail, (err) => {
@@ -1599,16 +1594,16 @@ jobs:
         };
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'repoOwner/repoName'
-            });
+            } });
         });
 
         it('returns a list of opened pull requests', () => {
-            githubMock.pullRequests.getAll.yieldsAsync(null, [
+            githubMock.pullRequests.getAll.yieldsAsync(null, { data: [
                 { number: 1 },
                 { number: 2 }
-            ]);
+            ] });
 
             return scm._getOpenedPRs(config).then((data) => {
                 assert.deepEqual(data, [
@@ -1664,16 +1659,16 @@ jobs:
         const sha = 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f';
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'repoOwner/repoName'
-            });
+            } });
         });
 
         it('returns a pull request with the given prNum', () => {
             githubMock.pullRequests.get.yieldsAsync(null,
-                { html_url: 'https://github.com/repoOwner/repoName/pull/1',
+                { data: { html_url: 'https://github.com/repoOwner/repoName/pull/1',
                     number: 1,
-                    head: { sha } }
+                    head: { sha } } }
             );
 
             return scm._getPrInfo(config).then((data) => {
@@ -1828,10 +1823,10 @@ jobs:
         };
 
         beforeEach(() => {
-            githubMock.repos.getById.yieldsAsync(null, {
+            githubMock.repos.getById.yieldsAsync(null, { data: {
                 full_name: 'dolores/violentdelights'
-            });
-            githubMock.repos.getBranches.yieldsAsync(null, [{
+            } });
+            githubMock.repos.getBranches.yieldsAsync(null, { data: [{
                 name: 'master',
                 commit: {
                     sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
@@ -1839,7 +1834,7 @@ jobs:
                 },
                 protected: true,
                 protection_url: 'https://api.github.com/protect'
-            }]);
+            }] });
         });
 
         it('gets branches', (done) => {
@@ -1874,10 +1869,11 @@ jobs:
 
                 fakeBranches.push(bInfo);
             }
-            githubMock.repos.getBranches.onCall(0).yieldsAsync(null, fakeBranches.slice(0, 100));
-            githubMock.repos.getBranches.onCall(1).yieldsAsync(null, fakeBranches.slice(100, 200));
-            githubMock.repos.getBranches.onCall(2).yieldsAsync(null, fakeBranches.slice(200, 300));
-            githubMock.repos.getBranches.onCall(3).yieldsAsync(null, []);
+            /* eslint-disable */
+            githubMock.repos.getBranches.onCall(0).yieldsAsync(null, { data: fakeBranches.slice(0, 100) });
+            githubMock.repos.getBranches.onCall(1).yieldsAsync(null, { data: fakeBranches.slice(100, 200) });
+            githubMock.repos.getBranches.onCall(2).yieldsAsync(null, { data: fakeBranches.slice(200, 300) });
+            githubMock.repos.getBranches.onCall(3).yieldsAsync(null, { data: [] });
             scm.getBranchList(branchListConfig).then((branches) => {
                 assert.equal(branches.length, 300);
                 done();


### PR DESCRIPTION
## Context
We were many versions behind on a github npm module we were using.

## Objective
This PR pulls in the latest version of `@octokit/rest` and updates code to comply.
### Major changes
- Most changes come from v9.0.0: https://github.com/octokit/rest.js/blob/f4845cffb392fcb0671d70e1e2779eabe0c8fd12/CHANGELOG.md#900
Responses before:
```
{
  repo: 'mytest',
  owner: 'tkyi'
}
```
Responses now:
```
{ 
  data: {
    repo: 'mytest',
    owner: 'tkyi'
  } 
}
```
- GHE support: Can no longer pass in `gheHost`, `gheProtocol`, and `pathPrefix` to the config, need to use `baseUrl` instead (https://www.npmjs.com/package/@octokit/rest#client-options)
- `editHook` takes in `hook_id` now vs `id` before (https://octokit.github.io/rest.js/#api-Repos-editHook)
- Don't need to pass in `host` to `getBranch`
- Updated tests to match

## Related links
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1042