### PR TITLE
fix(854): [small] normalize suspended user's permissions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const Scm = require('screwdriver-scm-base');
 const crypto = require('crypto');
+const winston = require('winston');
 const DEFAULT_AUTHOR = {
     avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
     name: 'n/a',
@@ -460,6 +461,10 @@ class GithubScm extends Scm {
         } catch (err) {
             // Suspended user
             if (err.code === 403) {
+                winston.info(
+                    `User's account suspended for ${scmInfo.owner}/${scmInfo.repo}, ` +
+                    'it will be removed from pipeline admins.');
+
                 return { admin: false, push: false, pull: false };
             }
 

--- a/index.js
+++ b/index.js
@@ -445,16 +445,26 @@ class GithubScm extends Scm {
             scmUri: config.scmUri,
             token: config.token
         });
-        const repo = await this.breaker.runCommand({
-            action: 'get',
-            token: config.token,
-            params: {
-                owner: scmInfo.owner,
-                repo: scmInfo.repo
-            }
-        });
 
-        return repo.data.permissions;
+        try {
+            const repo = await this.breaker.runCommand({
+                action: 'get',
+                token: config.token,
+                params: {
+                    owner: scmInfo.owner,
+                    repo: scmInfo.repo
+                }
+            });
+
+            return repo.data.permissions;
+        } catch (err) {
+            // Suspended user
+            if (err.code === 403) {
+                return { admin: false, push: false, pull: false };
+            }
+
+            throw err;
+        }
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "hoek": "^5.0.3",
     "joi": "^13.4.0",
     "screwdriver-data-schema": "^18.29.2",
-    "screwdriver-scm-base": "^4.2.0"
+    "screwdriver-scm-base": "^4.2.0",
+    "winston": "^2.4.2"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,7 @@ describe('index', function () {
     let scm;
     let githubMock;
     let githubMockClass;
+    let winstonMock;
 
     before(() => {
         mockery.enable({
@@ -64,8 +65,13 @@ describe('index', function () {
             }
         };
         githubMockClass = sinon.stub().returns(githubMock);
+        winstonMock = {
+            info: sinon.stub(),
+            error: sinon.stub()
+        };
 
         mockery.registerMock('@octokit/rest', githubMockClass);
+        mockery.registerMock('winston', winstonMock);
 
         // eslint-disable-next-line global-require
         GithubScm = require('../');
@@ -416,6 +422,12 @@ describe('index', function () {
                         type: 'oauth',
                         token: config.token
                     });
+
+                    assert.calledWith(
+                        winstonMock.info,
+                        "User's account suspended for screwdriver-cd/models, " +
+                        'it will be removed from pipeline admins.'
+                    );
                 })
                 .catch(() => {
                     assert(false, 'Error should be handled if error code is 403');


### PR DESCRIPTION
## Context

Currently, if a Pipeline contains  **suspended** admins, its build starting fails with the following UI error message.
```
{"message":"Sorry. Your account was suspended.","documentation_url":"https://developer.github.com/enterprise/2.11/v3"}
```
It is caused by the 403 response of the GitHub API for suspended users.

## Objective

This PR catches the 403 exception and returns a normal permission object (`{admin: false, push: false, pull: false}`, which means unauthorized).

## References

- https://github.com/screwdriver-cd/screwdriver/issues/854