### PR TITLE
refactor: [small] add logging unexpected runtime exceptions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -466,12 +466,14 @@ class GithubScm extends Scm {
      * @return {Promise}                    Resolves to the owner's repository permissions
      */
     async _getPermissions(config) {
-        const scmInfo = await this.lookupScmUri({
-            scmUri: config.scmUri,
-            token: config.token
-        });
+        let scmInfo;
 
         try {
+            scmInfo = await this.lookupScmUri({
+                scmUri: config.scmUri,
+                token: config.token
+            });
+
             const repo = await this.breaker.runCommand({
                 action: 'get',
                 token: config.token,

--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ class GithubScm extends Scm {
             return repo.data.permissions;
         } catch (err) {
             // Suspended user
-            if (err.code === 403) {
+            if (err.code === 404) {
                 winston.info(
                     `User's account suspended for ${scmInfo.owner}/${scmInfo.repo}, ` +
                     'it will be removed from pipeline admins.');

--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ class GithubScm extends Scm {
             return repo.data.permissions;
         } catch (err) {
             // Suspended user
-            if (err.code === 404) {
+            if (err.code === 404 && err.message.match(/suspend/i)) {
                 winston.info(
                     `User's account suspended for ${scmInfo.owner}/${scmInfo.repo}, ` +
                     'it will be removed from pipeline admins.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -399,10 +399,10 @@ describe('index', function () {
                 });
         });
 
-        it('catches and discards Github errors when it has a 403 error code', () => {
+        it('catches and discards Github errors when it has a 404 error code', () => {
             const err = new Error('Sorry. Your account was suspended.');
 
-            err.code = 403;
+            err.code = 404;
             githubMock.repos.get.yieldsAsync(err);
 
             return scm.getPermissions(config)
@@ -430,7 +430,7 @@ describe('index', function () {
                     );
                 })
                 .catch(() => {
-                    assert(false, 'Error should be handled if error code is 403');
+                    assert(false, 'Error should be handled if error code is 404');
                 });
         });
     });


### PR DESCRIPTION
## Context

Currently, exceptions for unexpected GitHub API responses are almost thrown to the API and UI layer and NOT logged. It causes too difficult to debug it about GitHub problems.

## Objective

This PR enables logging unexpected exceptions and re-throwing it.
 