### PR TITLE
fix: fix suspended user check.

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ class GithubScm extends Scm {
             return repo.data.permissions;
         } catch (err) {
             // Suspended user
-            if (err.code === 404 && err.message.match(/suspend/i)) {
+            if (err.message.match(/suspend/i)) {
                 winston.info(
                     `User's account suspended for ${scmInfo.owner}/${scmInfo.repo}, ` +
                     'it will be removed from pipeline admins.');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -399,10 +399,9 @@ describe('index', function () {
                 });
         });
 
-        it('catches and discards Github errors when it has a 404 error code', () => {
+        it('catches and discards Github errors when it has a suspended user error message', () => {
             const err = new Error('Sorry. Your account was suspended.');
 
-            err.code = 404;
             githubMock.repos.get.yieldsAsync(err);
 
             return scm.getPermissions(config)
@@ -430,7 +429,7 @@ describe('index', function () {
                     );
                 })
                 .catch(() => {
-                    assert(false, 'Error should be handled if error code is 404');
+                    assert(false, 'Error should be handled if error message has "suspend" string');
                 });
         });
     });


### PR DESCRIPTION
## Context

The error object for suspended user access does not have any status code (e.g. 403, 404)!
We should check the error message alone.

## References

- Error log sample
```
error:  message={"message":"Sorry. Your account was suspended.","documentation_url":"https://developer.github.com/enterprise/2.11/v3"}, stack=HttpError: {"message":"Sorry. Your account was suspended.","documentation_url":"https://developer.github.com/enterprise/2.11/v3"}
    at response.text.then.message (/usr/src/app/node_modules/@octokit/rest/lib/request/request.js:78:19)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7), name=HttpError, code=403, status=undefined, access-control-allow-origin=*, access-control-expose-headers=ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, connection=close, content-length=118, content-security-policy=default-src 'none', content-type=application/json; charset=utf-8, date=Wed, 25 Jul 2018 06:39:56 GMT, server=GitHub.com, status=403 Forbidden, strict-transport-security=max-age=31536000; includeSubdomains, x-content-type-options=nosniff, x-frame-options=deny, x-github-media-type=github.v3; format=json, x-github-request-id=7fcbcdfb-b9a3-40d8-80d1-db88e03c83e8, x-runtime-rack=0.030141, x-xss-protection=1; mode=block
```