### PR TITLE
feat(1355): Add method to add PR comment [4]

### DIFF
--- a/index.js
+++ b/index.js
@@ -1093,6 +1093,47 @@ class GithubScm extends Scm {
     }
 
     /**
+     * Add a PR comment
+     * @param  {Object}     config
+     * @param  {String}     config.comment     The PR comment
+     * @param  {Integer}    config.prNum       The PR number
+     * @param  {String}     config.scmUri      The SCM URI
+     * @param  {String}     config.token       Service token to authenticate with Github
+     * @return {Promise}                       Resolves when complete
+     */
+    async _addPrComment(config) {
+        const lookupConfig = {
+            scmUri: config.scmUri,
+            token: config.token
+        };
+
+        const scmInfo = await this.lookupScmUri(lookupConfig);
+
+        try {
+            const pullRequestComment = await this.breaker.runCommand({
+                action: 'createComment',
+                scopeType: 'issues',
+                token: config.token,
+                params: {
+                    body: config.comment,
+                    number: config.prNum,
+                    owner: scmInfo.owner,
+                    repo: scmInfo.repo
+                }
+            });
+
+            return {
+                commentId: `${pullRequestComment.data.id}`,
+                createTime: `${pullRequestComment.data.created_at}`,
+                username: pullRequestComment.data.user.login
+            };
+        } catch (err) {
+            winston.error('Failed to addPRComment: ', err);
+            throw err;
+        }
+    }
+
+    /**
      * Get an array of scm context (e.g. github:github.com)
      * @method getScmContexts
      * @return {Array}          Array of scm contexts

--- a/index.js
+++ b/index.js
@@ -1101,22 +1101,20 @@ class GithubScm extends Scm {
      * @param  {String}     config.token       Service token to authenticate with Github
      * @return {Promise}                       Resolves when complete
      */
-    async _addPrComment(config) {
-        const lookupConfig = {
-            scmUri: config.scmUri,
-            token: config.token
-        };
-
-        const scmInfo = await this.lookupScmUri(lookupConfig);
+    async _addPrComment({ comment, prNum, scmUri, token }) {
+        const scmInfo = await this.lookupScmUri({
+            scmUri,
+            token
+        });
 
         try {
             const pullRequestComment = await this.breaker.runCommand({
                 action: 'createComment',
                 scopeType: 'issues',
-                token: config.token,
+                token,
                 params: {
-                    body: config.comment,
-                    number: config.prNum,
+                    body: comment,
+                    number: prNum,
                     owner: scmInfo.owner,
                     repo: scmInfo.repo
                 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hoek": "^5.0.4",
     "joi": "^13.7.0",
     "screwdriver-data-schema": "^18.33.5",
-    "screwdriver-scm-base": "^4.4.3",
+    "screwdriver-scm-base": "^5.0.0",
     "winston": "^2.4.2"
   },
   "release": {

--- a/test/data/github.pull_request.createComment.json
+++ b/test/data/github.pull_request.createComment.json
@@ -1,0 +1,29 @@
+{
+  "id": 1,
+  "node_id": "MDEyOklzc3VlQ29tbWVudDE=",
+  "url": "https://api.github.com/repos/octocat/Hello-World/issues/comments/1",
+  "html_url": "https://github.com/octocat/Hello-World/issues/1347#issuecomment-1",
+  "body": "Me too",
+  "user": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "created_at": "2011-04-14T16:00:49Z",
+  "updated_at": "2011-04-14T16:00:49Z"
+}


### PR DESCRIPTION
## Context
It would be nice for users to be able to comment back on PRs through a build with relevant metadata.

## Objective
This PR adds a method to add a PR comment.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1355
Blocked by scm-base