### PR TITLE
fix(1355): Do not throw error when cannot add PR comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1127,7 +1127,8 @@ class GithubScm extends Scm {
             };
         } catch (err) {
             winston.error('Failed to addPRComment: ', err);
-            throw err;
+
+            return null;
         }
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1990,14 +1990,16 @@ jobs:
             });
         });
 
-        it('rejects when failing to get the pull request', () => {
+        it('returns null when failing to add the pull request comment', () => {
             const testError = new Error('testError');
 
             githubMock.issues.createComment.yieldsAsync(testError);
 
-            return scm._addPrComment(config).then(assert.fail, (err) => {
-                assert.instanceOf(err, Error);
-                assert.strictEqual(testError.message, err.message);
+            return scm._addPrComment(config).then((data) => {
+                assert.isNull(data);
+            }).catch((err) => {
+                assert.deepEqual(err, testError);
+                assert.calledWith(githubMock.issues.createComment, config);
             });
         });
     });


### PR DESCRIPTION
## Context
The call to `addPrComment` makes the build hang when it fails.

## Objective
This PR returns null instead of throwing an error when cannot add PR comment to Github.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1355