### PR TITLE
fix(1355): Use token from config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 artifacts/
 features/*.feature
+mytest.js

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ class GithubScm extends Scm {
             gheHost: joi.string().optional().description('GitHub Enterpise host'),
             username: joi.string().optional().default('sd-buildbot'),
             email: joi.string().optional().default('dev-null@screwdriver.cd'),
+            token: joi.string().optional().description('Token for PR comments'),
             https: joi.boolean().optional().default(false),
             oauthClientId: joi.string().required(),
             oauthClientSecret: joi.string().required(),
@@ -1111,7 +1112,7 @@ class GithubScm extends Scm {
             const pullRequestComment = await this.breaker.runCommand({
                 action: 'createComment',
                 scopeType: 'issues',
-                token,
+                token: this.config.token, // need to use a token with public_repo permissions
                 params: {
                     body: comment,
                     number: prNum,

--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ class GithubScm extends Scm {
             gheHost: joi.string().optional().description('GitHub Enterpise host'),
             username: joi.string().optional().default('sd-buildbot'),
             email: joi.string().optional().default('dev-null@screwdriver.cd'),
-            token: joi.string().optional().description('Token for PR comments'),
+            commentUserToken: joi.string().optional().description('Token for PR comments'),
             https: joi.boolean().optional().default(false),
             oauthClientId: joi.string().required(),
             oauthClientSecret: joi.string().required(),
@@ -1112,7 +1112,7 @@ class GithubScm extends Scm {
             const pullRequestComment = await this.breaker.runCommand({
                 action: 'createComment',
                 scopeType: 'issues',
-                token: this.config.token, // need to use a token with public_repo permissions
+                token: this.config.commentUserToken, // need to use a token with public_repo permissions
                 params: {
                     body: comment,
                     number: prNum,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,7 +91,8 @@ describe('index', function () {
             },
             oauthClientId: 'abcdefg',
             oauthClientSecret: 'hijklmno',
-            secret: 'somesecret'
+            secret: 'somesecret',
+            token: 'sometoken'
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe('index', function () {
             oauthClientId: 'abcdefg',
             oauthClientSecret: 'hijklmno',
             secret: 'somesecret',
-            token: 'sometoken'
+            commentUserToken: 'sometoken'
         });
     });
 


### PR DESCRIPTION
Need `public_repo` scoped token to make a PR comment. The most secure solution is to add a `token` to scm settings that had no specific access to repos but has that scope.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1355