### PR TITLE
Fix: Add error log

### DIFF
--- a/index.js
+++ b/index.js
@@ -1171,6 +1171,8 @@ class GithubScm extends Scm {
 
             return result.checkoutUrl.startsWith(checkoutSshHost);
         } catch (err) {
+            winston.error('Failed to run canHandleWebhook', err);
+
             return false;
         }
     }


### PR DESCRIPTION
# Context
If there is an error parsing a webhook, canHandleWebhook just returns false and we cannot know the reason why it failed.

# Objective
* Print error log with an error object after the error is caught