### PR TITLE
feat(1440): Use custom context and description to updateCommitStatus [3]

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,28 +622,32 @@ class GithubScm extends Scm {
      * @param  {String}   config.jobName      Optional name of the job that finished
      * @param  {String}   config.url          Target url
      * @param  {Number}   config.pipelineId   Pipeline Id
+     * @param  {String}   config.context      Status context
+     * @param  {String}   config.description  Status description
      * @return {Promise}                      Resolves when operation completed
      */
-    async _updateCommitStatus(config) {
+    async _updateCommitStatus({ scmUri, sha, buildStatus, token, jobName, url,
+        pipelineId, context, description }) {
         const scmInfo = await this.lookupScmUri({
-            scmUri: config.scmUri,
-            token: config.token
+            scmUri,
+            token
         });
-        const jobName = config.jobName.replace(/^PR-\d+/g, 'PR');
+        const statusTitle = context ? `Screwdriver/${pipelineId}/${context}` :
+            `Screwdriver/${pipelineId}/${jobName.replace(/^PR-\d+/g, 'PR')}`; // (e.g. Screwdriver/12/PR:main)
         const params = {
-            context: `Screwdriver/${config.pipelineId}/${jobName}`,
-            description: DESCRIPTION_MAP[config.buildStatus],
+            context: statusTitle,
+            description: description || DESCRIPTION_MAP[buildStatus],
             repo: scmInfo.repo,
-            sha: config.sha,
-            state: STATE_MAP[config.buildStatus] || 'failure',
+            sha,
+            state: STATE_MAP[buildStatus] || 'failure',
             owner: scmInfo.owner,
-            target_url: config.url
+            target_url: url
         };
 
         try {
             const status = await this.breaker.runCommand({
                 action: 'createStatus',
-                token: config.token,
+                token,
                 params
             });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -634,6 +634,33 @@ describe('index', function () {
                 })
         );
 
+        it('promises to update commit status on success with custom context', () => {
+            config.context = 'findbugs';
+            config.description = '923 issues found. Previous count: 914 issues.';
+
+            return scm.updateCommitStatus(config)
+                .then((result) => {
+                    assert.deepEqual(result, data);
+
+                    assert.calledWith(githubMock.repos.getById, {
+                        id: '14052'
+                    });
+                    assert.calledWith(githubMock.repos.createStatus, {
+                        owner: 'screwdriver-cd',
+                        repo: 'models',
+                        sha: config.sha,
+                        state: 'success',
+                        description: '923 issues found. Previous count: 914 issues.',
+                        context: 'Screwdriver/675/findbugs',
+                        target_url: 'https://foo.bar'
+                    });
+                    assert.calledWith(githubMock.authenticate, {
+                        type: 'oauth',
+                        token: config.token
+                    });
+                });
+        });
+
         it('sets context for PR when jobName passed in', () => {
             config.jobName = 'PR-15:test';
 


### PR DESCRIPTION
## Context
Users would like to add custom Git statuses for commits.

## Objective
This PR adds `context` and `description` fields to be passed into the `scm.updateCommitStatus` method. The `context` will be the key provided by the user. `description` will be the message they want to show.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1440
Blocked by https://github.com/screwdriver-cd/data-schema/pull/307