### PR TITLE
[3] feat: Add pr title to the event

### DIFF
--- a/index.js
+++ b/index.js
@@ -953,6 +953,7 @@ class GithubScm extends Scm {
         case 'pull_request': {
             let action = hoek.reach(webhookPayload, 'action');
             const prNum = hoek.reach(webhookPayload, 'pull_request.number');
+            const prTitle = hoek.reach(webhookPayload, 'pull_request.title');
             const baseSource = hoek.reach(webhookPayload, 'pull_request.base.repo.id');
             const headSource = hoek.reach(webhookPayload, 'pull_request.head.repo.id');
             const prSource = baseSource === headSource ? 'branch' : 'fork';
@@ -973,6 +974,7 @@ class GithubScm extends Scm {
                 branch: hoek.reach(webhookPayload, 'pull_request.base.ref'),
                 checkoutUrl,
                 prNum,
+                prTitle,
                 prRef: `pull/${prNum}/merge`,
                 prSource,
                 sha: hoek.reach(webhookPayload, 'pull_request.head.sha'),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1102,6 +1102,7 @@ jobs:
                 checkoutUrl: 'git@github.com:baxterthehacker/public-repo.git',
                 prNum: 1,
                 prRef: 'pull/1/merge',
+                prTitle: 'Update the README with new information',
                 sha: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
                 prSource: 'branch',
                 type: 'pr',


### PR DESCRIPTION
## Context
We want to add pr title to the event for using it in notification.

## Objective
Add prTitle to _parseHook return when the github-event type is pull_request.

## References
Related PRs:
data-shema https://github.com/screwdriver-cd/data-schema/pull/310
models https://github.com/screwdriver-cd/models/pull/321
screwdriver https://github.com/screwdriver-cd/screwdriver/pull/1456

CI test will pass after https://github.com/screwdriver-cd/data-schema/pull/310 is merged.