### PR TITLE
feat: update octokit to 16.x  BREAKING CHANGE: updating major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "sinon": "^1.17.5"
   },
   "dependencies": {
-    "@octokit/rest": "^15.18.1",
+    "@octokit/rest": "^16.16.3",
     "circuit-fuses": "^2.0.3",
-    "hoek": "^5.0.4",
+    "hoek": "^6.1.2",
     "joi": "^13.7.0",
     "screwdriver-data-schema": "^18.39.1",
     "screwdriver-scm-base": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.5"
+    "sinon": "^7.2.7"
   },
   "dependencies": {
     "@octokit/rest": "^16.16.3",


### PR DESCRIPTION
There are many deprecations between octokit 15.x and 16.x. So [the api document](https://octokit.github.io/rest.js/) is hard to read.
This PR updates octokit to 16.x.

We also should think about using [octokit throttling](https://github.com/octokit/rest.js#throttling) instead of circuit breaker retry.

## References
- [deprecations list](https://github.com/octokit/rest.js/releases/tag/v15.18.0#deprecations)
- [Release v16.0.1 (including Breaking changes list)](https://github.com/octokit/rest.js/releases/tag/v16.0.1)
- [Alias legacy scopes for backwards compatibility by gr2m · Pull Request #1135 · octokit/rest.js](https://github.com/octokit/rest.js/pull/1135)