### PR TITLE
feat: add committer to decorateCommit

### DIFF
--- a/index.js
+++ b/index.js
@@ -855,19 +855,38 @@ class GithubScm extends Scm {
                 }
             });
 
+            const authorLogin = hoek.reach(commit, 'data.author.login');
+            const authorName = hoek.reach(commit, 'data.commit.author.name');
+            const committerLogin = hoek.reach(commit, 'data.committer.login');
+            const committerName = hoek.reach(commit, 'data.commit.committer.name');
             let author = Object.assign({}, DEFAULT_AUTHOR);
+            let committer = Object.assign({}, DEFAULT_AUTHOR);
 
-            if (commit.data.author && commit.data.author.login) {
+            if (authorLogin) {
                 author = await this.decorateAuthor({
                     token: config.token,
-                    username: commit.data.author.login
+                    username: authorLogin
                 });
-            } else if (commit.data.commit && commit.data.commit.author) {
-                author.name = commit.data.commit.author.name;
+            } else if (authorName) {
+                author.name = authorName;
+            }
+
+            if (committerLogin) {
+                if (committerLogin === authorLogin) {
+                    committer = author;
+                } else {
+                    committer = await this.decorateAuthor({
+                        token: config.token,
+                        username: committerLogin
+                    });
+                }
+            } else if (committerName) {
+                committer.name = committerName;
             }
 
             return {
                 author,
+                committer,
                 message: commit.data.commit.message,
                 url: commit.data.html_url
             };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "circuit-fuses": "^2.0.3",
     "hoek": "^6.1.2",
     "joi": "^13.7.0",
-    "screwdriver-data-schema": "^18.44.2",
+    "screwdriver-data-schema": "^18.45.4",
     "screwdriver-scm-base": "^5.1.0",
     "winston": "^2.4.2"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1479,6 +1479,12 @@ jobs:
                         url: 'https://internal-ghe.mycompany.com/notbrucewayne',
                         username: 'notbrucewayne'
                     },
+                    committer: {
+                        avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                        name: 'n/a',
+                        username: 'n/a',
+                        url: 'https://cd.screwdriver.cd/'
+                    },
                     message: 'some commit message that is here',
                     url: 'https://link.to/commitDiff'
                 });
@@ -1514,6 +1520,12 @@ jobs:
             }).then((data) => {
                 assert.deepEqual(data, {
                     author: {
+                        avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                        name: 'n/a',
+                        url: 'https://cd.screwdriver.cd/',
+                        username: 'n/a'
+                    },
+                    committer: {
                         avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
                         name: 'n/a',
                         url: 'https://cd.screwdriver.cd/',


### PR DESCRIPTION
 add committer to decorateCommit

example commit payload from github: https://developer.github.com/v3/repos/commits/#get-a-single-commit

Related to https://github.com/screwdriver-cd/screwdriver/issues/1437