### PR TITLE
fix: use pull_number instead of number

### DIFF
--- a/index.js
+++ b/index.js
@@ -851,7 +851,7 @@ class GithubScm extends Scm {
                 params: {
                     owner: scmInfo.owner,
                     repo: scmInfo.repo,
-                    sha: config.sha
+                    commit_sha: config.sha
                 }
             });
 
@@ -1204,7 +1204,7 @@ class GithubScm extends Scm {
                 scopeType: 'pulls',
                 token: config.token,
                 params: {
-                    number: config.prNum,
+                    pull_number: config.prNum,
                     owner: scmInfo.owner,
                     repo: scmInfo.repo
                 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -294,7 +294,7 @@ describe('index', function () {
                     assert.calledWith(githubMock.pulls.get, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
-                        number: config.prNum
+                        pull_number: config.prNum
                     });
                     delete config.prNum;
                 });
@@ -1495,7 +1495,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: repoOwner,
                     repo: repoName,
-                    sha
+                    commit_sha: sha
                 });
                 assert.calledWith(githubMock.users.getByUsername, {
                     username
@@ -1541,7 +1541,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: repoOwner,
                     repo: repoName,
-                    sha
+                    commit_sha: sha
                 });
                 assert.callCount(githubMock.users.getByUsername, 0);
             });
@@ -1564,7 +1564,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: 'banana',
                     repo: 'peel',
-                    sha
+                    commit_sha: sha
                 });
             });
         });
@@ -1982,7 +1982,7 @@ jobs:
                 assert.calledWith(githubMock.pulls.get, {
                     owner: 'repoOwner',
                     repo: 'repoName',
-                    number: 1
+                    pull_number: 1
                 });
             });
         });
@@ -2016,7 +2016,7 @@ jobs:
                 assert.calledWith(githubMock.pulls.get, {
                     owner: 'repoOwner',
                     repo: 'repoName',
-                    number: 1
+                    pull_number: 1
                 });
             });
         });


### PR DESCRIPTION
`number` is deprecated. `sha` is deprecated.

seeing this in logs:
```
{ Deprecation: [@octokit/rest] "number" parameter is deprecated for ".pulls.get()". Use "pull_number" instead
at Object.keys.forEach.key (/usr/src/app/node_modules/@octokit/rest/plugins/register-endpoints/register-endpoints.js:73:26)
at Array.forEach (<anonymous>)

{ Deprecation: [@octokit/rest] "sha" parameter is deprecated for ".repos.getCommit()". Use "commit_sha" instead
```

