### PR TITLE
fix: add err logs for getBranchList

### DIFF
--- a/index.js
+++ b/index.js
@@ -1376,6 +1376,9 @@ class GithubScm extends Scm {
             scmInfo,
             page: 1,
             token: config.token
+        }).catch((err) => {
+            winston.error('Failed to getBranchList: ', err);
+            throw err;
         });
     }
 }


### PR DESCRIPTION
add err logs for getBranchList, other functions all have it