### PR TITLE
fix(823): [2] Add some release fields for parseHook

### DIFF
--- a/index.js
+++ b/index.js
@@ -1100,7 +1100,10 @@ class GithubScm extends Scm {
                 username: hoek.reach(webhookPayload, 'sender.login'),
                 hookId,
                 scmContext: scmContexts[0],
-                ref: hoek.reach(webhookPayload, 'release.tag_name')
+                ref: hoek.reach(webhookPayload, 'release.tag_name'),
+                releaseId: hoek.reach(webhookPayload, 'release.id'),
+                releaseName: hoek.reach(webhookPayload, 'release.name') || '',
+                releaseAuthor: hoek.reach(webhookPayload, 'release.author.login') || ''
             };
         }
         case 'create': {

--- a/index.js
+++ b/index.js
@@ -1101,7 +1101,7 @@ class GithubScm extends Scm {
                 hookId,
                 scmContext: scmContexts[0],
                 ref: hoek.reach(webhookPayload, 'release.tag_name'),
-                releaseId: hoek.reach(webhookPayload, 'release.id'),
+                releaseId: hoek.reach(webhookPayload, 'release.id').toString(),
                 releaseName: hoek.reach(webhookPayload, 'release.name') || '',
                 releaseAuthor: hoek.reach(webhookPayload, 'release.author.login') || ''
             };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1199,7 +1199,10 @@ jobs:
                         username: 'Codertocat',
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
                         scmContext: 'github:github.com',
-                        ref: '0.0.1'
+                        ref: '0.0.1',
+                        releaseId: 11248810,
+                        releaseName: '',
+                        releaseAuthor: 'Codertocat'
                     });
                 });
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1200,7 +1200,7 @@ jobs:
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
                         scmContext: 'github:github.com',
                         ref: '0.0.1',
-                        releaseId: 11248810,
+                        releaseId: '11248810',
                         releaseName: '',
                         releaseAuthor: 'Codertocat'
                     });


### PR DESCRIPTION
## Context
SD can execute release/tag trigger, but it can't provide release/tag info(ex. name).
SD user want to get release/tag info.

## Objective
Add some release fields to returned value from parseHook when release action is hooked.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/823#issuecomment-490014132
This PR is blocked by these PRs.
https://github.com/screwdriver-cd/data-schema/pull/337