### PR TITLE
fix(1455): fix scm url with rootDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -934,12 +934,12 @@ class GithubScm extends Scm {
 
         const { host, owner, repo, branch, rootDir } = await this.lookupScmUri(lookupConfig);
 
-        const baseUrl = `https://${host}/${owner}/${repo}/tree/${branch}`;
+        const baseUrl = `${host}/${owner}/${repo}/tree/${branch}`;
 
         return {
             branch,
             name: `${owner}/${repo}`,
-            url: rootDir ? Path.join(baseUrl, rootDir) : baseUrl,
+            url: `https://${rootDir ? Path.join(baseUrl, rootDir) : baseUrl}`,
             rootDir: rootDir || ''
         };
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1693,7 +1693,7 @@ jobs:
                 assert.deepEqual(data, {
                     branch: 'boat',
                     name: 'iAm/theCaptain',
-                    url: 'https:/github.com/iAm/theCaptain/tree/boat/src/app/component',
+                    url: 'https://github.com/iAm/theCaptain/tree/boat/src/app/component',
                     rootDir: 'src/app/component'
                 });
                 assert.calledWith(githubMock.request, 'GET /repositories/:id',


### PR DESCRIPTION
shouldn't use Path.join with http protocol part.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1455