### PR TITLE
fix(1646): [3] add baseBranch to return value in getPrInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1245,7 +1245,8 @@ class GithubScm extends Scm {
                 username: pullRequestInfo.data.user.login,
                 title: pullRequestInfo.data.title,
                 createTime: pullRequestInfo.data.created_at,
-                userProfile: pullRequestInfo.data.user.html_url
+                userProfile: pullRequestInfo.data.user.html_url,
+                baseBranch: pullRequestInfo.data.base.ref
             };
         } catch (err) {
             winston.error('Failed to getPrInfo: ', err);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2084,7 +2084,8 @@ jobs:
                         username: 'octocat',
                         title: 'new-feature',
                         createTime: '2011-01-26T19:01:12Z',
-                        userProfile: 'https://github.com/octocat'
+                        userProfile: 'https://github.com/octocat',
+                        baseBranch: 'master'
                     }
                 );
                 assert.calledWith(githubMock.request, 'GET /repositories/:id', { id: '111' });
@@ -2118,7 +2119,8 @@ jobs:
                         username: 'octocat',
                         title: 'new-feature',
                         createTime: '2011-01-26T19:01:12Z',
-                        userProfile: 'https://github.com/octocat'
+                        userProfile: 'https://github.com/octocat',
+                        baseBranch: 'master'
                     }
                 );
                 assert.notCalled(githubMock.request);


### PR DESCRIPTION
**Issue #, if available:** https://github.com/screwdriver-cd/screwdriver/issues/1646
When `pipeline.prSync` is called, it needs base branch info for the PR to get next job for `~pr:<branchName>`.

**Description of changes:**
This PR allow `getPrInfo` to return `baseBranch` value which contains the base branch name of a PR.

This PR is requires below changes before merge.
https://github.com/screwdriver-cd/scm-base/pull/70
https://github.com/screwdriver-cd/data-schema/pull/339

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
