### PR TITLE
fix: deprecation of octokit and Node Buffer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -667,14 +667,11 @@ class GithubScm extends Scm {
                 params: {
                     owner: config.owner,
                     repo: config.repo,
-                    ref: config.ref,
-                    mediaType: {
-                        format: 'sha'
-                    }
+                    ref: config.ref
                 }
             });
 
-            return commit.data;
+            return commit.data.sha;
         } catch (err) {
             winston.error('Failed to getCommitRefSha: ', err);
             throw err;

--- a/index.js
+++ b/index.js
@@ -772,7 +772,7 @@ class GithubScm extends Scm {
                 throw new Error(`Path (${fullPath}) does not point to file`);
             }
 
-            return new Buffer(file.data.content, file.data.encoding).toString();
+            return Buffer.from(file.data.content, file.data.encoding).toString();
         } catch (err) {
             winston.error('Failed to getFile: ', err);
             throw err;

--- a/index.js
+++ b/index.js
@@ -870,7 +870,7 @@ class GithubScm extends Scm {
                 params: {
                     owner: scmInfo.owner,
                     repo: scmInfo.repo,
-                    commit_sha: config.sha
+                    ref: config.sha
                 }
             });
 

--- a/index.js
+++ b/index.js
@@ -1276,7 +1276,7 @@ class GithubScm extends Scm {
                 token: this.config.commentUserToken, // need to use a token with public_repo permissions
                 params: {
                     body: comment,
-                    number: prNum,
+                    issue_number: prNum,
                     owner: scmInfo.owner,
                     repo: scmInfo.repo
                 }

--- a/index.js
+++ b/index.js
@@ -662,16 +662,19 @@ class GithubScm extends Scm {
     async _getCommitRefSha(config) {
         try {
             const commit = await this.breaker.runCommand({
-                action: 'getCommitRefSha',
+                action: 'getCommit',
                 token: config.token,
                 params: {
                     owner: config.owner,
                     repo: config.repo,
-                    ref: config.ref
+                    ref: config.ref,
+                    mediaType: {
+                        format: 'sha'
+                    }
                 }
             });
 
-            return commit.data.sha;
+            return commit.data;
         } catch (err) {
             winston.error('Failed to getCommitRefSha: ', err);
             throw err;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "joi": "^13.7.0",
     "screwdriver-data-schema": "^18.46.0",
     "screwdriver-scm-base": "^5.2.0",
-    "winston": "^2.4.2"
+    "winston": "^3.2.1"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -358,15 +358,12 @@ describe('index', function () {
             token: 'somerandomtoken',
             owner: 'screwdriver-cd',
             repo: 'models',
-            ref: 'v0.0.1',
-            mediaType: {
-                format: 'sha'
-            }
+            ref: 'v0.0.1'
         };
         const sha = '6dcb09b5b57875f334f61aebed695e2e4193db5e';
 
         it('promises to get the commit sha', () => {
-            githubMock.repos.getCommit.resolves({ data: sha });
+            githubMock.repos.getCommit.resolves({ data: { sha } });
 
             return scm.getCommitRefSha(config)
                 .then((data) => {
@@ -375,10 +372,7 @@ describe('index', function () {
                     assert.calledWith(githubMock.repos.getCommit, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
-                        ref: 'v0.0.1',
-                        mediaType: {
-                            format: 'sha'
-                        }
+                        ref: 'v0.0.1'
                     });
                 });
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1580,7 +1580,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: repoOwner,
                     repo: repoName,
-                    commit_sha: sha
+                    ref: sha
                 });
                 assert.calledWith(githubMock.users.getByUsername, {
                     username
@@ -1626,7 +1626,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: repoOwner,
                     repo: repoName,
-                    commit_sha: sha
+                    ref: sha
                 });
                 assert.callCount(githubMock.users.getByUsername, 0);
             });
@@ -1649,7 +1649,7 @@ jobs:
                 assert.calledWith(githubMock.repos.getCommit, {
                     owner: 'banana',
                     repo: 'peel',
-                    commit_sha: sha
+                    ref: sha
                 });
             });
         });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2188,7 +2188,7 @@ jobs:
                 assert.calledWith(githubMock.issues.createComment, {
                     owner: 'repoOwner',
                     repo: 'repoName',
-                    number: 1,
+                    issue_number: 1,
                     body: comment
                 });
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -358,21 +358,27 @@ describe('index', function () {
             token: 'somerandomtoken',
             owner: 'screwdriver-cd',
             repo: 'models',
-            ref: 'v0.0.1'
+            ref: 'v0.0.1',
+            mediaType: {
+                format: 'sha'
+            }
         };
         const sha = '6dcb09b5b57875f334f61aebed695e2e4193db5e';
 
         it('promises to get the commit sha', () => {
-            githubMock.repos.getCommitRefSha.resolves({ data: { sha } });
+            githubMock.repos.getCommit.resolves({ data: sha });
 
             return scm.getCommitRefSha(config)
                 .then((data) => {
                     assert.deepEqual(data, sha);
 
-                    assert.calledWith(githubMock.repos.getCommitRefSha, {
+                    assert.calledWith(githubMock.repos.getCommit, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
-                        ref: 'v0.0.1'
+                        ref: 'v0.0.1',
+                        mediaType: {
+                            format: 'sha'
+                        }
                     });
                 });
         });
@@ -380,7 +386,7 @@ describe('index', function () {
         it('throws error when failed to get the commit sha', () => {
             const err = new Error('githubError');
 
-            githubMock.repos.getCommitRefSha.rejects(err);
+            githubMock.repos.getCommit.rejects(err);
 
             return scm.getCommitRefSha(config)
                 .then(() => assert.fail('This should not fail the test'))


### PR DESCRIPTION
## Context
 We found 5 deprecation messages at log 
```
{ Deprecation: [@octokit/rest] "commit_sha" parameter is deprecated for ".repos.getCommit()". Use "ref" instead
{ Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
{ Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.createComment()". Use "issue_number" instead
{ Deprecation: [@octokit/rest] "Get the SHA-1 of a commit reference" will be removed. Use "Get a single commit" instead with media type format set to "sha" instead.
```
and only when  node version is 10 of higher
```
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We fixed deprecations above-mentioned 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
- [octokit api endpoints](https://github.com/octokit/rest.js/blob/494d75b9ac0be2e64a3382d233f328ae07279071/plugins/rest-api-endpoints/routes.json)
- [Node.js API doc](https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe)
- we needed to add `mediaType` param to [data-schema#345](https://github.com/screwdriver-cd/data-schema/pull/345) to fix deprecation of getCommitRefSha function
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
