### PR TITLE
fix: [2] Use 'getRef' instead of 'getCommit' in 'getCommitRefSha'

### DIFF
--- a/index.js
+++ b/index.js
@@ -657,21 +657,23 @@ class GithubScm extends Scm {
      * @param  {String}   config.owner     The owner of the target repository
      * @param  {String}   config.repo      The target repository name
      * @param  {String}   config.ref       The reference which we want
+     * @param  {String}   config.refType   The reference type. ex. branch is 'heads', tag is 'tags'.
      * @return {Promise}                   Resolves to the commit sha
      */
     async _getCommitRefSha(config) {
         try {
             const commit = await this.breaker.runCommand({
-                action: 'getCommit',
+                action: 'getRef',
                 token: config.token,
+                scopeType: 'git',
                 params: {
                     owner: config.owner,
                     repo: config.repo,
-                    ref: config.ref
+                    ref: `${config.refType}/${config.ref}`
                 }
             });
 
-            return commit.data.sha;
+            return commit.data.object.sha;
         } catch (err) {
             winston.error('Failed to getCommitRefSha: ', err);
             throw err;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,6 +73,9 @@ describe('index', function () {
             orgs: {
                 getMembershipForAuthenticatedUser: sinon.stub()
             },
+            git: {
+                getRef: sinon.stub()
+            },
             request: sinon.stub(),
             paginate: sinon.stub()
         };
@@ -358,21 +361,22 @@ describe('index', function () {
             token: 'somerandomtoken',
             owner: 'screwdriver-cd',
             repo: 'models',
+            refType: 'tags',
             ref: 'v0.0.1'
         };
         const sha = '6dcb09b5b57875f334f61aebed695e2e4193db5e';
 
         it('promises to get the commit sha', () => {
-            githubMock.repos.getCommit.resolves({ data: { sha } });
+            githubMock.git.getRef.resolves({ data: { object: { sha } } });
 
             return scm.getCommitRefSha(config)
                 .then((data) => {
                     assert.deepEqual(data, sha);
 
-                    assert.calledWith(githubMock.repos.getCommit, {
+                    assert.calledWith(githubMock.git.getRef, {
                         owner: 'screwdriver-cd',
                         repo: 'models',
-                        ref: 'v0.0.1'
+                        ref: 'tags/v0.0.1'
                     });
                 });
         });


### PR DESCRIPTION
## Context
getCommitRefSha function can't get sha correctly when tag name and branch name are same.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR change `getCommit` action to `getRef` action, and add 'refType' param 
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[octokit/rest getRef](https://octokit.github.io/rest.js/#octokit-routes-git-get-ref)
[data-schema PR](https://github.com/screwdriver-cd/data-schema/pull/347)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
