### PR TITLE
fix(1747) : parse commit authors from webhook payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -1093,8 +1093,10 @@ class GithubScm extends Scm {
         }
         case 'push':
 
-            for (let i = 0; i < commits.length; i += 1) {
-                commitAuthors.push(commits[i].author.name);
+            if (Array.isArray(commits)) {
+                commits.forEach((commit) => {
+                    commitAuthors.push(commit.author.name);
+                });
             }
 
             return {

--- a/index.js
+++ b/index.js
@@ -1051,6 +1051,8 @@ class GithubScm extends Scm {
         const hookId = payloadHeaders['x-github-delivery'];
         const checkoutUrl = hoek.reach(webhookPayload, 'repository.ssh_url');
         const scmContexts = this._getScmContexts();
+        const commitAuthors = [];
+        const commits = hoek.reach(webhookPayload, 'commits');
 
         switch (type) {
         case 'pull_request': {
@@ -1090,6 +1092,11 @@ class GithubScm extends Scm {
             };
         }
         case 'push':
+
+            for (let i = 0; i < commits.length; i += 1) {
+                commitAuthors.push(commits[i].author.name);
+            }
+
             return {
                 action: 'push',
                 branch: hoek.reach(webhookPayload, 'ref').replace(/^refs\/heads\//, ''),
@@ -1097,6 +1104,7 @@ class GithubScm extends Scm {
                 sha: hoek.reach(webhookPayload, 'after'),
                 type: 'repo',
                 username: hoek.reach(webhookPayload, 'sender.login'),
+                commitAuthors,
                 lastCommitMessage: hoek.reach(webhookPayload, 'head_commit.message') || '',
                 hookId,
                 scmContext: scmContexts[0],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "circuit-fuses": "^2.0.3",
     "hoek": "^6.1.2",
     "joi": "^13.7.0",
-    "screwdriver-data-schema": "^18.46.0",
+    "screwdriver-data-schema": "^18.46.13",
     "screwdriver-scm-base": "^5.2.0",
     "winston": "^3.2.1"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1181,6 +1181,7 @@ jobs:
                         sha: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
                         type: 'repo',
                         username: 'baxterthehacker2',
+                        commitAuthors: ['baxterthehacker'],
                         lastCommitMessage: 'lastcommitmessage',
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
                         scmContext: 'github:github.com',


### PR DESCRIPTION
## Context

Currently there's a mismatch in v3 and v4 ci skip logic. To change v4 ci skip logic to match v3 we need to parse an additional field from webhook payload.

## Objective

parse an additional field 'commit authors' from webhook payload

## References

screwdriver-cd/screwdriver#1747

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
