### PR TITLE
fix(1764): able to handle annotated tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -674,6 +674,7 @@ class GithubScm extends Scm {
             });
 
             if (refObj.data.object.type === 'tag') {
+                // annotated tag
                 const tagObj = await this.breaker.runCommand({
                     action: 'getTag',
                     token: config.token,
@@ -687,6 +688,7 @@ class GithubScm extends Scm {
 
                 return tagObj.data.object.sha;
             } else if (refObj.data.object.type === 'commit') {
+                // commit or lightweight tag
                 return refObj.data.object.sha;
             }
             throw new Error(`Cannot handle ${refObj.data.object.type} type`);

--- a/index.js
+++ b/index.js
@@ -662,7 +662,7 @@ class GithubScm extends Scm {
      */
     async _getCommitRefSha(config) {
         try {
-            const commit = await this.breaker.runCommand({
+            const refObj = await this.breaker.runCommand({
                 action: 'getRef',
                 token: config.token,
                 scopeType: 'git',
@@ -673,7 +673,23 @@ class GithubScm extends Scm {
                 }
             });
 
-            return commit.data.object.sha;
+            if (refObj.data.object.type === 'tag') {
+                const tagObj = await this.breaker.runCommand({
+                    action: 'getTag',
+                    token: config.token,
+                    scopeType: 'git',
+                    params: {
+                        owner: config.owner,
+                        repo: config.repo,
+                        tag_sha: refObj.data.object.sha
+                    }
+                });
+
+                return tagObj.data.object.sha;
+            } else if (refObj.data.object.type === 'commit') {
+                return refObj.data.object.sha;
+            }
+            throw new Error(`Cannot handle ${refObj.data.object.type} type`);
         } catch (err) {
             winston.error('Failed to getCommitRefSha: ', err);
             throw err;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -404,7 +404,7 @@ describe('index', function () {
                 });
         });
 
-        it('throw error when getRef API returned unexpected type', () => {
+        it('throws error when getRef API returned unexpected type', () => {
             const type = Math.random().toString(36).slice(-8);
             const err = new Error(`Cannot handle ${type} type`);
 


### PR DESCRIPTION
## Context
fix bug that sd cannot fire annotated tag trigger.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When refSha API return type of `tag`, sd call getTag API and get commit sha. It is because refSha API returns tag_sha when the type is `tag`.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1764

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
