### PR TITLE
feat(scm-github): Allow editing of existing PR bot comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ class GithubScm extends Scm {
 
     /**
      * Edit a particular comment in the PR
-     * @async  editPrCpmment
+     * @async  editPrComment
      * @param  {Integer}  commentId         The id of the particular comment to be edited
      * @param  {Object}   scmInfo           The information regarding SCM like repo, owner
      * @param  {String}   comment           The new comment body
@@ -292,7 +292,8 @@ class GithubScm extends Scm {
             return pullRequestComment;
         } catch (err) {
             logger.error('Failed to edit PR comment: ', err);
-            throw err;
+
+            return null;
         }
     }
 


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1714

## Objective

Before this, when multiple builds took place, it resulted in multiple meta PR comments. To tackle that, the comments for that PR is listed and if a bot comment is found, it is edited, else a new comment is created.

## References

screwdriver-cd/screwdriver#1714

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
