### PR TITLE
fix(2029): [2] Add prSource to prInfo return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1383,6 +1383,9 @@ class GithubScm extends Scm {
                     repo: scmInfo.repo
                 }
             });
+            const prSource = pullRequestInfo.data.head.repo.id === pullRequestInfo.data.base.repo.id
+                ? 'branch'
+                : 'fork';
 
             return {
                 name: `PR-${pullRequestInfo.data.number}`,
@@ -1395,7 +1398,8 @@ class GithubScm extends Scm {
                 createTime: pullRequestInfo.data.created_at,
                 userProfile: pullRequestInfo.data.user.html_url,
                 baseBranch: pullRequestInfo.data.base.ref,
-                mergeable: pullRequestInfo.data.mergeable
+                mergeable: pullRequestInfo.data.mergeable,
+                prSource
             };
         } catch (err) {
             logger.error('Failed to getPrInfo: ', err);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2164,7 +2164,8 @@ jobs:
                         userProfile: 'https://github.com/octocat',
                         prBranchName: 'new-topic',
                         baseBranch: 'master',
-                        mergeable: true
+                        mergeable: true,
+                        prSource: 'branch'
                     }
                 );
                 assert.calledWith(githubMock.request, 'GET /repositories/:id', { id: '111' });
@@ -2201,7 +2202,8 @@ jobs:
                         userProfile: 'https://github.com/octocat',
                         prBranchName: 'new-topic',
                         baseBranch: 'master',
-                        mergeable: true
+                        mergeable: true,
+                        prSource: 'branch'
                     }
                 );
                 assert.notCalled(githubMock.request);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When PR builds are restarted by API call, prSource information is disappear.
Because of this, restarted PR builds cannot trigger next Jobs.

Tests are failed until screwdriver-cd/scm-base#78 is merged.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I added prSource to getPrInfo return value.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2029

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
