### PR TITLE
fix(2017): switch to Octokit verify method

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@octokit/rest": "~16.33",
+    "@octokit/webhooks": "~7.6.2",
     "circuit-fuses": "^4.0.4",
     "hoek": "^6.1.2",
     "joi": "^13.7.0",


### PR DESCRIPTION
## Context

Currently our custom logic to verify webhook signature breaks SSH Certificate Authorities
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

Remove our custom logic and use Octokit Webhook's [verify](https://github.com/octokit/webhooks.js/tree/master/src/verify) method instead
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2017
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
