### PR TITLE
fix(2094): [1] return empty file when screwdriver.yaml is not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -913,7 +913,7 @@ class GithubScm extends Scm {
             logger.error('Failed to getFile: ', err);
 
             if (err.status === 404) {
-                // Returns a empty file if there are no screwdriver.yaml
+                // Returns an empty file if there is no screwdriver.yaml
                 return '';
             }
 

--- a/index.js
+++ b/index.js
@@ -911,6 +911,12 @@ class GithubScm extends Scm {
             return Buffer.from(file.data.content, file.data.encoding).toString();
         } catch (err) {
             logger.error('Failed to getFile: ', err);
+
+            if (err.status === 404) {
+                // Returns a empty file if there are no screwdriver.yaml
+                return Buffer.from([]);
+            }
+
             throw err;
         }
     }

--- a/index.js
+++ b/index.js
@@ -914,7 +914,7 @@ class GithubScm extends Scm {
 
             if (err.status === 404) {
                 // Returns a empty file if there are no screwdriver.yaml
-                return Buffer.from([]);
+                return '';
             }
 
             throw err;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1073,30 +1073,6 @@ jobs:
                 });
         });
 
-        it('returns an error when github command fails', () => {
-            const err = new Error('githubError');
-
-            err.status = 403;
-
-            githubMock.repos.getContents.rejects(err);
-
-            return scm.getFile(config)
-                .then(() => {
-                    assert.fail('This should not fail the test');
-                })
-                .catch((error) => {
-                    assert.calledWith(githubMock.repos.getContents, {
-                        owner: 'screwdriver-cd',
-                        repo: 'models',
-                        path: config.path,
-                        ref: config.ref
-                    });
-
-                    assert.deepEqual(error, err);
-                    assert.strictEqual(scm.breaker.getTotalRequests(), 2);
-                });
-        });
-
         it('returns error when path is not a file', () => {
             const expectedErrorMessage = 'Path (screwdriver.yaml) does not point to file';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1053,6 +1053,50 @@ jobs:
                 });
         });
 
+        it('promises to get empty content when file is not found', () => {
+            const err = new Error('githubError');
+
+            err.status = 404;
+
+            githubMock.repos.getContents.rejects(err);
+
+            return scm.getFile(config)
+                .then((data) => {
+                    assert.deepEqual(data, '');
+
+                    assert.calledWith(githubMock.repos.getContents, {
+                        owner: 'screwdriver-cd',
+                        repo: 'models',
+                        path: config.path,
+                        ref: config.ref
+                    });
+                });
+        });
+
+        it('returns an error when github command fails', () => {
+            const err = new Error('githubError');
+
+            err.status = 403;
+
+            githubMock.repos.getContents.rejects(err);
+
+            return scm.getFile(config)
+                .then(() => {
+                    assert.fail('This should not fail the test');
+                })
+                .catch((error) => {
+                    assert.calledWith(githubMock.repos.getContents, {
+                        owner: 'screwdriver-cd',
+                        repo: 'models',
+                        path: config.path,
+                        ref: config.ref
+                    });
+
+                    assert.deepEqual(error, err);
+                    assert.strictEqual(scm.breaker.getTotalRequests(), 2);
+                });
+        });
+
         it('returns error when path is not a file', () => {
             const expectedErrorMessage = 'Path (screwdriver.yaml) does not point to file';
 
@@ -1076,7 +1120,7 @@ jobs:
         it('returns an error when github command fails', () => {
             const err = new Error('githubError');
 
-            err.status = 404;
+            err.status = 403;
 
             githubMock.repos.getContents.rejects(err);
 


### PR DESCRIPTION
## Context
This PR makes it possible to hundle pipelines of repository which has no `screwdriver.yaml`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We fixed to return empty file when screwdriver.yaml is not found.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2094
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
