### PR TITLE
feat(1079): Add key pair generation method and push public key to scm [4]

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { verify } = require('@octokit/webhooks');
 const hoek = require('hoek');
 const Path = require('path');
 const joi = require('joi');
+const keygen = require('ssh-keygen');
 const schema = require('screwdriver-data-schema');
 const CHECKOUT_URL_REGEX = schema.config.regex.CHECKOUT_URL;
 const Scm = require('screwdriver-scm-base');
@@ -295,6 +296,62 @@ class GithubScm extends Scm {
             logger.error('Failed to edit PR comment: ', err);
 
             return null;
+        }
+    }
+
+    /**
+     * Generate a deploy private and public key pair
+     * @async  generateDeployKey
+     * @return {Promise}                    Resolves to object containing the public and private key pair
+     */
+    async generateDeployKey() {
+        return new Promise((resolve, reject) => {
+            const location = `${__dirname}/keys_rsa`; // Directory where keys will be stored temporarily
+            const comment = this.config.email;
+            const password = ''; // Passphrase left empty
+            const format = 'PEM'; // default is RFC4716
+
+            keygen({
+                location,
+                comment,
+                password,
+                read: true,
+                format
+            }, (err, out) => {
+                if (err) {
+                    logger.error('Failed to create keys: ', err);
+                    reject(err);
+                }
+                resolve(out);
+            });
+        });
+    }
+
+    /**
+     * Adds deploy public key to the github repo and returns the private key
+     * @async  _addDeployKey
+     * @param  {Object}     config
+     * @param  {Object}     config.token        Admin token for repo
+     * @param  {String}     config.checkoutUrl  The checkoutUrl to parse
+     * @return {Promise}                        Resolves to the private key string
+     */
+    async _addDeployKey(config) {
+        const { token, checkoutUrl } = config;
+        const scmInfo = getInfo(checkoutUrl);
+        const keys = await this.generateDeployKey();
+
+        try {
+            await this.breaker.runCommand({
+                scopeType: 'request',
+                route: `POST /repos/${scmInfo.owner}/${scmInfo.repo}/keys`,
+                token,
+                params: { title: 'sd@screwdriver.cd', key: keys.pubKey, read_only: true }
+            });
+
+            return keys.key;
+        } catch (err) {
+            logger.error('Failed to add token: ', err);
+            throw err;
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ const DESCRIPTION_MAP = {
 const PERMITTED_RELEASE_EVENT = [
     'published'
 ];
+const DEPLOY_KEYS_FILE = `${__dirname}/keys_rsa`; // Directory where keys will be stored temporarily
+const DEPLOY_KEYS_FORMAT = 'PEM'; // Default is RFC4716
+const DEPLOY_KEYS_PASSWORD = ''; // Password left empty
+const DEPLOY_KEY_TITLE = 'sd@screwdriver.cd';
 
 /**
  * Get repo information
@@ -307,10 +311,10 @@ class GithubScm extends Scm {
      */
     async generateDeployKey() {
         return new Promise((resolve, reject) => {
-            const location = `${__dirname}/keys_rsa`; // Directory where keys will be stored temporarily
+            const location = DEPLOY_KEYS_FILE;
             const comment = this.config.email;
-            const password = ''; // Passphrase left empty
-            const format = 'PEM'; // default is RFC4716
+            const password = DEPLOY_KEYS_PASSWORD;
+            const format = DEPLOY_KEYS_FORMAT;
 
             keygen({
                 location,
@@ -350,7 +354,7 @@ class GithubScm extends Scm {
                 token,
                 params: { owner: scmInfo.owner,
                     repo: scmInfo.repo,
-                    title: 'sd@screwdriver.cd',
+                    title: DEPLOY_KEY_TITLE,
                     key: keys.pubKey,
                     read_only: true }
             });
@@ -363,11 +367,11 @@ class GithubScm extends Scm {
     }
 
     /**
-     * Adds deploy public key to the github repo and returns the private key
-     * @async  _checkAutoDeployKeyGeneration
+     * Returns whether auto deploy key generation is enabled or not
+     * @async  _autoDeployKeyGenerationEnabled
      * @return {Boolean}                        Resolves to the private key string
      */
-    async _checkAutoDeployKeyGeneration() {
+    async _autoDeployKeyGenerationEnabled() {
         return this.config.autoDeployKeyGeneration;
     }
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "hoek": "^6.1.2",
     "joi": "^13.7.0",
     "screwdriver-data-schema": "^19.1.1",
+    "screwdriver-logger": "^1.0.0",
     "screwdriver-scm-base": "^6.0.0",
-    "screwdriver-logger": "^1.0.0"
+    "ssh-keygen": "^0.5.0"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1906,9 +1906,9 @@ jobs:
         });
     });
 
-    describe('checkAutoDeployKeyGeneration', () => {
+    describe('autoDeployKeyGenerationEnabled', () => {
         it('returns a boolean check', () =>
-            scm.checkAutoDeployKeyGeneration().then((check) => {
+            scm.autoDeployKeyGenerationEnabled().then((check) => {
                 assert.isBoolean(check);
             })
         );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,7 @@ const testPrFiles = require('./data/github.pull_request.files.json');
 const testPrGet = require('./data/github.pull_request.get.json');
 const testPrGetNullMergeable = require('./data/github.pull_request.get.nullMergeable.json');
 const testPrCreateComment = require('./data/github.pull_request.createComment.json');
+const { describe } = require('joi');
 
 sinon.assert.expose(assert, {
     prefix: ''
@@ -1864,6 +1865,15 @@ jobs:
                 assert.calledWith(githubMock.request, 'GET /repositories/:id',
                     { id: '102498' }
                 );
+            });
+        });
+    });
+
+    describe('generateDeployKey', () => {
+        it('returns a public and private key pair object', () => {
+            scm.generateDeployKey().then((keys) => {
+                assert.isObject(keys);
+                assert.hasAllKeys(keys, ['key', 'pubKey']);
             });
         });
     });


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR contains the implementation of the automatic generation of private and public deploy keys and also addition of keys to the scm repo. This PR will automate the deploy key mechanism with getting activated with just a flag.

## References

Fixes screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
