### PR TITLE
fix: Add mergeable check

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1197,7 +1197,23 @@ jobs:
                 scmUri: 'github.com:28476:master',
                 prNum: 1
             }, 0).then((result) => {
-                assert.deepEqual(result, { success: true, mergeable: true });
+                assert.deepEqual(result, {
+                    success: true,
+                    pullRequestInfo: {
+                        baseBranch: 'master',
+                        createTime: '2011-01-26T19:01:12Z',
+                        mergeable: true,
+                        name: 'PR-1',
+                        prBranchName: 'new-topic',
+                        prSource: 'branch',
+                        ref: 'pull/1/merge',
+                        sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+                        title: 'new-feature',
+                        url: 'https://github.com/octocat/Hello-World/pull/1',
+                        userProfile: 'https://github.com/octocat',
+                        username: 'octocat'
+                    }
+                });
             });
         });
 
@@ -1211,7 +1227,23 @@ jobs:
                 scmUri: 'github.com:28476:master',
                 prNum: 1
             }, 0).then((result) => {
-                assert.deepEqual(result, { success: true, mergeable: true });
+                assert.deepEqual(result, {
+                    success: true,
+                    pullRequestInfo: {
+                        baseBranch: 'master',
+                        createTime: '2011-01-26T19:01:12Z',
+                        mergeable: true,
+                        name: 'PR-1',
+                        prBranchName: 'new-topic',
+                        prSource: 'branch',
+                        ref: 'pull/1/merge',
+                        sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+                        title: 'new-feature',
+                        url: 'https://github.com/octocat/Hello-World/pull/1',
+                        userProfile: 'https://github.com/octocat',
+                        username: 'octocat'
+                    }
+                });
             });
         });
 
@@ -1224,7 +1256,23 @@ jobs:
                 scmUri: 'github.com:28476:master',
                 prNum: 1
             }, 0).then((result) => {
-                assert.deepEqual(result, { success: false });
+                assert.deepEqual(result, {
+                    success: false,
+                    pullRequestInfo: {
+                        baseBranch: 'master',
+                        createTime: '2011-01-26T19:01:12Z',
+                        mergeable: null,
+                        name: 'PR-1',
+                        prBranchName: 'new-topic',
+                        prSource: 'branch',
+                        ref: 'pull/1/merge',
+                        sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e',
+                        title: 'new-feature',
+                        url: 'https://github.com/octocat/Hello-World/pull/1',
+                        userProfile: 'https://github.com/octocat',
+                        username: 'octocat'
+                    }
+                });
             });
         });
     });


### PR DESCRIPTION
## Context
Very rarely, Screwdriver.cd tries to refer to `SHA: 0000000000000000000000000000000000000000`, and GitHub responds with `422 Unprocessable Entity`. Perhaps I think we also need to check for mergeable (like https://github.com/screwdriver-cd/scm-github/pull/1450 ) on `getCommitSha()`.

## Objective
I want to fix unnecessary access to github with `SHA: 0000000000000000000000000000000000000000`.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1468

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
