### PR TITLE
fix: increase page size for PR files request

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const MATCH_COMPONENT_USER_NAME = 2;
 const MATCH_COMPONENT_HOST_NAME = 1;
 const WEBHOOK_PAGE_SIZE = 30;
 const BRANCH_PAGE_SIZE = 100;
+const PR_FILES_PAGE_SIZE = 100;
 const POLLING_INTERVAL = 0.2;
 const POLLING_MAX_ATTEMPT = 10;
 const STATE_MAP = {
@@ -1120,7 +1121,8 @@ class GithubScm extends Scm {
                     params: {
                         owner: scmInfo.owner,
                         repo: scmInfo.repo,
-                        number: prNum
+                        number: prNum,
+                        per_page: PR_FILES_PAGE_SIZE
                     }
                 });
 


### PR DESCRIPTION
## Context

Pull request with large number of committed files is more prone to timeout from breaker perspective

## Objective

increase page size to 100, instead of default 30, for the paginated request for pull request files to 1) reduce overall request duration 2) reduce overall chance of getting rate limited

## References

https://developer.github.com/v3/pulls/#list-pull-requests-files

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
