### PR TITLE
refactor(1079): Refactor addDeployKey to use request scope format

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,12 +353,10 @@ class GithubScm extends Scm {
 
         try {
             await this.breaker.runCommand({
-                action: 'createDeployKey',
-                scopeType: 'repos',
+                scopeType: 'request',
+                route: `POST /repos/${owner}/${repo}/keys`,
                 token,
                 params: {
-                    owner,
-                    repo,
                     title: DEPLOY_KEY_GENERATOR_CONFIG.DEPLOY_KEY_TITLE,
                     key: pubKey,
                     read_only: true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,8 +72,7 @@ describe('index', function () {
                 getCommitRefSha: sinon.stub(),
                 getContents: sinon.stub(),
                 listHooks: sinon.stub(),
-                listBranches: sinon.stub(),
-                createDeployKey: sinon.stub()
+                listBranches: sinon.stub()
             },
             users: {
                 getByUsername: sinon.stub()
@@ -1946,7 +1945,7 @@ jobs:
 
         it('returns a private key', async () => {
             generateDeployKeyStub.returns(Promise.resolve({ pubKey, key: privKey }));
-            githubMock.repos.createDeployKey.resolves({ data: pubKey });
+            githubMock.request.resolves({ data: pubKey });
             const privateKey = await scm.addDeployKey(addDepKeyConfig);
 
             assert.isString(privateKey);


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR refactors the addDeployKey method to use the request type format of the createDeployKey.

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
