### PR TITLE
feat(1415): Add provision for custom actions in addWebhook

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,8 @@ class GithubScm extends Scm {
         let action = 'createWebhook';
         const params = {
             active: true,
-            events: config.actions,
+            events: config.actions.length === 0 ?
+                ['push', 'pull_request', 'create', 'release'] : config.actions,
             owner: config.scmInfo.owner,
             repo: config.scmInfo.repo,
             name: 'web',

--- a/index.js
+++ b/index.js
@@ -421,13 +421,14 @@ class GithubScm extends Scm {
      * @param  {Object}     config.scmInfo      Information about the repo
      * @param  {String}     config.token        Admin token for repo
      * @param  {String}     config.url          Payload destination url for webhook notifications
+     * @param  {String}     config.actions      Actions for the webhook events
      * @return {Promise}                        Resolves when complete
      */
     async _createWebhook(config) {
         let action = 'createHook';
         const params = {
             active: true,
-            events: ['push', 'pull_request', 'create', 'release'],
+            events: config.actions,
             owner: config.scmInfo.owner,
             repo: config.scmInfo.repo,
             name: 'web',
@@ -464,6 +465,7 @@ class GithubScm extends Scm {
      * @param  {String}    config.scmUri      The SCM URI to add the webhook to
      * @param  {String}    config.token       Service token to authenticate with Github
      * @param  {String}    config.webhookUrl  The URL to use for the webhook notifications
+     * @param  {Array}     config.actions     The list of actions to be added for this webhook
      * @return {Promise}                      Resolve means operation completed without failure
      */
     async _addWebhook(config) {
@@ -481,6 +483,7 @@ class GithubScm extends Scm {
         return this._createWebhook({
             hookInfo,
             scmInfo,
+            actions: config.actions,
             token: config.token,
             url: config.webhookUrl
         });

--- a/index.js
+++ b/index.js
@@ -425,7 +425,7 @@ class GithubScm extends Scm {
      * @return {Promise}                        Resolves when complete
      */
     async _createWebhook(config) {
-        let action = 'createHook';
+        let action = 'createWebhook';
         const params = {
             active: true,
             events: config.actions,
@@ -440,7 +440,7 @@ class GithubScm extends Scm {
         };
 
         if (config.hookInfo) {
-            action = 'updateHook';
+            action = 'updateWebhook';
             Object.assign(params, { hook_id: config.hookInfo.id });
         }
 

--- a/index.js
+++ b/index.js
@@ -374,6 +374,20 @@ class GithubScm extends Scm {
     }
 
     /**
+     * Get the webhook events mapping of screwdriver events and scm events
+     * @async _getWebhookEventsMapping
+     * @return {Object}     Returns a mapping of the events
+     */
+    async _getWebhookEventsMapping() {
+        return {
+            '~pr': 'pull_request',
+            '~release': 'release',
+            '~tag': 'create',
+            '~commit': 'push'
+        };
+    }
+
+    /**
      * Look up a webhook from a repo
      * @async  _findWebhook
      * @param  {Object}     config

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2039,9 +2039,9 @@ jobs:
         const webhookConfig = {
             scmUri: 'github.com:1263:branchName',
             token: 'fakeToken',
-            webhookUrl: 'https://somewhere.in/the/interwebs'
+            webhookUrl: 'https://somewhere.in/the/interwebs',
+            actions: ['push', 'pull_request', 'create', 'release']
         };
-        const webhookEvents = ['push', 'pull_request', 'create', 'release'];
 
         beforeEach(() => {
             githubMock.request.resolves({ data: {
@@ -2068,7 +2068,7 @@ jobs:
                         secret: 'somesecret',
                         url: 'https://somewhere.in/the/interwebs'
                     },
-                    events: webhookEvents,
+                    events: webhookConfig.actions,
                     name: 'web',
                     owner: 'dolores',
                     repo: 'violentdelights'
@@ -2093,7 +2093,7 @@ jobs:
                         secret: 'somesecret',
                         url: 'https://somewhere.in/the/interwebs'
                     },
-                    events: webhookEvents,
+                    events: webhookConfig.actions,
                     hook_id: 783150,
                     name: 'web',
                     owner: 'dolores',
@@ -2126,7 +2126,7 @@ jobs:
                         secret: 'somesecret',
                         url: 'https://somewhere.in/the/interwebs'
                     },
-                    events: webhookEvents,
+                    events: webhookConfig.actions,
                     hook_id: 783150,
                     name: 'web',
                     owner: 'dolores',


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1415

## Objective

This PR adds provision for custom actions in addWebhook, to be used while adding multiple webhooks with different actions.

## References

screwdriver-cd/screwdriver#1415

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
