### PR TITLE
fix: noisy logs, no commit found for sha

### DIFF
--- a/index.js
+++ b/index.js
@@ -1265,6 +1265,7 @@ class GithubScm extends Scm {
         const scmContexts = this._getScmContexts();
         const commitAuthors = [];
         const commits = hoek.reach(webhookPayload, 'commits');
+        const deleted = hoek.reach(webhookPayload, 'deleted');
 
         const checkoutSshHost = this.config.gheHost
             ? this.config.gheHost : 'github.com';
@@ -1343,6 +1344,7 @@ class GithubScm extends Scm {
                 lastCommitMessage: hoek.reach(webhookPayload, 'head_commit.message') || '',
                 hookId,
                 scmContext: scmContexts[0],
+                deleted,
                 ref: hoek.reach(webhookPayload, 'ref')
             };
         }

--- a/index.js
+++ b/index.js
@@ -1333,6 +1333,10 @@ class GithubScm extends Scm {
                 });
             }
 
+            if (deleted) {
+                return null;
+            }
+
             return {
                 action: 'push',
                 branch: hoek.reach(webhookPayload, 'ref').replace(/^refs\/heads\//, ''),
@@ -1344,7 +1348,6 @@ class GithubScm extends Scm {
                 lastCommitMessage: hoek.reach(webhookPayload, 'head_commit.message') || '',
                 hookId,
                 scmContext: scmContexts[0],
-                deleted,
                 ref: hoek.reach(webhookPayload, 'ref')
             };
         }

--- a/test/data/github.push.deleted.json
+++ b/test/data/github.push.deleted.json
@@ -1,0 +1,165 @@
+{
+  "ref": "refs/heads/master",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": true,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "committer": {
+        "name": "baxterthehacker",
+        "email": "baxterthehacker@users.noreply.github.com",
+        "username": "baxterthehacker"
+      },
+      "added": [
+        "README.md"
+      ],
+      "removed": [
+        "screwdriver.yaml"
+      ],
+      "modified": [
+        "README.md",
+        "package.json"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "tree_id": "f9d2a07e9488b91af2641b26b9407fe22a451433",
+    "distinct": true,
+    "message": "lastcommitmessage",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "committer": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com",
+      "username": "baxterthehacker"
+    },
+    "added": [
+      "README.md"
+    ],
+    "removed": [
+      "screwdriver.yaml"
+    ],
+    "modified": [
+      "README.md",
+      "package.json"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "public-repo",
+    "full_name": "baxterthehacker/public-repo",
+    "owner": {
+      "name": "baxterthehacker",
+      "email": "baxterthehacker@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/baxterthehacker/public-repo",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/baxterthehacker/public-repo",
+    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
+    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
+    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
+    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
+    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
+    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
+    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
+    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
+    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
+    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
+    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
+    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
+    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
+    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/baxterthehacker/public-repo.git",
+    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
+    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
+    "svn_url": "https://github.com/baxterthehacker/public-repo",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "baxterthehacker",
+    "email": "baxterthehacker@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "baxterthehacker2",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/baxterthehacker2",
+    "html_url": "https://github.com/baxterthehacker2",
+    "followers_url": "https://api.github.com/users/baxterthehacker2/followers",
+    "following_url": "https://api.github.com/users/baxterthehacker2/following{/other_user}",
+    "gists_url": "https://api.github.com/users/baxterthehacker2/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/baxterthehacker2/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/baxterthehacker2/subscriptions",
+    "organizations_url": "https://api.github.com/users/baxterthehacker2/orgs",
+    "repos_url": "https://api.github.com/users/baxterthehacker2/repos",
+    "events_url": "https://api.github.com/users/baxterthehacker2/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/baxterthehacker2/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,6 +8,7 @@ const testPayloadClose = require('./data/github.pull_request.closed.json');
 const testPayloadOpen = require('./data/github.pull_request.opened.json');
 const testPayloadOpenFork = require('./data/github.pull_request.opened-fork.json');
 const testPayloadPush = require('./data/github.push.json');
+const testPayloadPushDeleted = require('./data/github.push.deleted.json');
 const testPayloadPushTag = require('./data/github.push.tag.json');
 const testPayloadRelease = require('./data/github.release.json');
 const testPayloadReleaseBadAction = require('./data/github.release.badAction.json');
@@ -1323,9 +1324,18 @@ jobs:
                         lastCommitMessage: 'lastcommitmessage',
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
                         scmContext: 'github:github.com',
-                        deleted: false,
                         ref: 'refs/heads/master'
                     });
+                });
+        });
+
+        it('parses a payload for a delete event payload', () => {
+            testHeaders['x-github-event'] = 'push';
+            testHeaders['x-hub-signature'] = 'sha1=f2589b49939e662188aed20967779a3e500149af';
+
+            return scm.parseHook(testHeaders, testPayloadPushDeleted)
+                .then((result) => {
+                    assert.equal(result, null);
                 });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1323,6 +1323,7 @@ jobs:
                         lastCommitMessage: 'lastcommitmessage',
                         hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
                         scmContext: 'github:github.com',
+                        deleted: false,
                         ref: 'refs/heads/master'
                     });
                 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Such errors occurs in a situation, and it is noisy in any investigation or analysis.
```
Getting errors with [{"action":"getCommit","token":"248ec46cbf868bfe999bf6590c0ba42ee8cd90a2","params":{"owner":"yoshwata-test","repo":"branch-filter-test","ref":"0000000000000000000000000000000000000000"}}]: HttpError: No commit found for SHA: 0000000000000000000000000000000000000000
```

The situation is
- When a branch is deleted
- the branch is match with the branch filter regex.

`00000` means that deleted branch is not exist anymore.

~~Test will fail before  https://github.com/screwdriver-cd/data-schema/pull/410 is applied.~~

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

API does not emit `No commit found for SHA: 0000~` error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/410
https://github.com/screwdriver-cd/scm-github/pull/179

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
