### PR TITLE
fix(1969): Fix branch from release hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -1378,7 +1378,7 @@ class GithubScm extends Scm {
 
             return {
                 action: 'release',
-                branch: hoek.reach(webhookPayload, 'release.target_commitish'),
+                branch: hoek.reach(webhookPayload, 'repository.default_branch'),
                 checkoutUrl,
                 type: 'repo',
                 username: hoek.reach(webhookPayload, 'sender.login'),


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When we make release choosing from "Recent Commits" , hook's `release.target_commitish` field is not a branch name but a commit sha.
Therefore, `release.target_commitish` field should not be used as a branch.

Because a release references tag when determine build's commit sha and tag hook event uses `repository.default_branch` as a branch, release hook event should better to use `repository.default_branch` as a branch too.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Use `repository.default_branch` field as a branch for hook.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#1969

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
