### PR TITLE
fix: [1] Change the getCommitSha error format

### DIFF
--- a/index.js
+++ b/index.js
@@ -885,7 +885,7 @@ class GithubScm extends Scm {
             return branch.data.commit.sha;
         } catch (err) {
             logger.error('Failed to getCommitSha: ', err);
-            throw new boom.Boom(err.message, { statusCode: err.status });
+            throw boom.boomify(err, { statusCode: err.status });
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+const boom = require('@hapi/boom');
 const Breaker = require('circuit-fuses').breaker;
 const { Octokit } = require('@octokit/rest');
 const { verify } = require('@octokit/webhooks');
@@ -884,7 +885,7 @@ class GithubScm extends Scm {
             return branch.data.commit.sha;
         } catch (err) {
             logger.error('Failed to getCommitSha: ', err);
-            throw err;
+            throw new boom.Boom(err.message, { statusCode: err.status });
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "mocha": "^8.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "nyc": "^15.0.0",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "sinon": "^7.5.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
+    "@hapi/boom": "^9.1.1",
     "@hapi/hoek": "^9.0.4",
     "@octokit/rest": "^18.0.0",
     "@octokit/webhooks": "^7.6.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,6 +3,7 @@
 const { assert } = require('chai');
 const mockery = require('mockery');
 const sinon = require('sinon');
+const boom = require('@hapi/boom');
 
 const testPayloadClose = require('./data/github.pull_request.closed.json');
 const testPayloadOpen = require('./data/github.pull_request.opened.json');
@@ -367,7 +368,9 @@ describe('index', function () {
             return scm.getCommitSha(config).then(() => {
                 assert.fail('This should not fail the test');
             }).catch((err) => {
-                assert.deepEqual(err, error);
+                const expected = new boom.Boom(error.message);
+
+                assert.deepEqual(err, expected);
 
                 assert.calledWith(githubMock.repos.getBranch, {
                     owner: 'screwdriver-cd',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -368,7 +368,7 @@ describe('index', function () {
             return scm.getCommitSha(config).then(() => {
                 assert.fail('This should not fail the test');
             }).catch((err) => {
-                const expected = new boom.Boom(error.message);
+                const expected = boom.boomify(error, { statusCode: error.status });
 
                 assert.deepEqual(err, expected);
 


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`getCommitSha` uses the original error format. This is not properly recognized by `Hapi`. For example, a 404 error is recognized as a 500 error. We fix this by using `boom`.

## Objective
- We add `Boom`.
- We change the format of errors returned by `getCommitSha` to use `Boom`.
- We change the test accordingly.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## Related PR
https://github.com/screwdriver-cd/screwdriver/pull/2362

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
