### PR TITLE
feat(2398): Read rootDir from checkoutUrl [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,6 +523,7 @@ class GithubScm extends Scm {
      * @param  {String}    [config.rootDir]      Root directory
      * @param  {String}    [config.scmContext]   The scm context name
      * @param  {String}    [config.manifest]     Repo manifest URL (only defined if `screwdriver.cd/repoManifest` annotation is)
+     * @param  {Object}    [config.parentConfig] Config for parent pipeline
      * @return {Promise}                         Resolves to object containing name and checkout commands
      */
     async _getCheckoutCommand(config) {
@@ -1433,10 +1434,9 @@ class GithubScm extends Scm {
      * @param  {String}     config.checkoutUrl  The checkoutUrl to parse
      * @param  {String}     [config.rootDir]    The root directory
      * @param  {String}     config.token        The token used to authenticate to the SCM service
-     * @return {Promise}                        Resolves to an ID of 'serviceName:repoId:branchName'
+     * @return {Promise}                        Resolves to an ID of 'serviceName:repoId:branchName:rootDir'
      */
-    async _parseUrl(config) {
-        const { checkoutUrl, rootDir, token } = config;
+    async _parseUrl({ checkoutUrl, rootDir, token }) {
         const scmInfo = getInfo(checkoutUrl, rootDir);
         const { host, branch, rootDir: sourceDir } = scmInfo;
         const myHost = this.config.gheHost || 'github.com';

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const DEFAULT_AUTHOR = {
     username: 'n/a',
     url: 'https://cd.screwdriver.cd/'
 };
+const MATCH_COMPONENT_ROOTDIR_NAME = 5;
 const MATCH_COMPONENT_BRANCH_NAME = 4;
 const MATCH_COMPONENT_REPO_NAME = 3;
 const MATCH_COMPONENT_USER_NAME = 2;
@@ -55,9 +56,10 @@ const DEPLOY_KEY_GENERATOR_CONFIG = {
  * Get repo information
  * @method getInfo
  * @param  {String}  scmUrl      scmUrl of the repo
- * @return {Object}              An object with the user, repo, host, and branch
+ * @param  {String}  [rootDir]   Root dir of the pipeline
+ * @return {Object}              An object with the user, repo, host, branch, and rootDir
  */
-function getInfo(scmUrl) {
+function getInfo(scmUrl, rootDir) {
     const matched = (schema.config.regex.CHECKOUT_URL).exec(scmUrl);
 
     // Check if regex did not pass
@@ -66,12 +68,14 @@ function getInfo(scmUrl) {
     }
 
     const branch = matched[MATCH_COMPONENT_BRANCH_NAME];
+    const rootDirFromScmUrl = matched[MATCH_COMPONENT_ROOTDIR_NAME];
 
     return {
         owner: matched[MATCH_COMPONENT_USER_NAME],
         repo: matched[MATCH_COMPONENT_REPO_NAME],
         host: matched[MATCH_COMPONENT_HOST_NAME],
-        branch: branch ? branch.slice(1) : undefined
+        branch: branch ? branch.slice(1) : undefined,
+        rootDir: rootDir || (rootDirFromScmUrl ? rootDirFromScmUrl.slice(1) : undefined)
     };
 }
 
@@ -1433,19 +1437,20 @@ class GithubScm extends Scm {
      */
     async _parseUrl(config) {
         const { checkoutUrl, rootDir, token } = config;
-        const scmInfo = getInfo(checkoutUrl);
+        const scmInfo = getInfo(checkoutUrl, rootDir);
+        const { host, branch, rootDir: sourceDir } = scmInfo;
         const myHost = this.config.gheHost || 'github.com';
 
-        if (scmInfo.host !== myHost) {
+        if (host !== myHost) {
             const message = 'This checkoutUrl is not supported for your current login host.';
 
             throw new Error(message);
         }
 
         const { repoId, defaultBranch } = await this._getRepoInfo(scmInfo, token, checkoutUrl);
-        const scmUri = `${scmInfo.host}:${repoId}:${scmInfo.branch || defaultBranch}`;
+        const scmUri = `${host}:${repoId}:${branch || defaultBranch}`;
 
-        return rootDir ? `${scmUri}:${rootDir}` : scmUri;
+        return sourceDir ? `${scmUri}:${sourceDir}` : scmUri;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@octokit/webhooks": "^7.24.3",
     "circuit-fuses": "^4.0.5",
     "joi": "^17.4.0",
-    "screwdriver-data-schema": "^21.2.6",
+    "screwdriver-data-schema": "^21.2.7",
     "screwdriver-logger": "^1.0.2",
     "screwdriver-scm-base": "^7.1.3",
     "ssh-keygen": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.4",
-    "@octokit/rest": "^18.0.0",
-    "@octokit/webhooks": "^7.6.2",
-    "circuit-fuses": "^4.0.4",
-    "joi": "^17.2.1",
-    "screwdriver-data-schema": "^21.0.0",
-    "screwdriver-logger": "^1.0.0",
-    "screwdriver-scm-base": "^7.0.0",
+    "@hapi/hoek": "^9.1.1",
+    "@octokit/rest": "^18.5.2",
+    "@octokit/webhooks": "^7.24.3",
+    "circuit-fuses": "^4.0.5",
+    "joi": "^17.4.0",
+    "screwdriver-data-schema": "^21.2.6",
+    "screwdriver-logger": "^1.0.2",
+    "screwdriver-scm-base": "^7.1.3",
     "ssh-keygen": "^0.5.0"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1528,7 +1528,7 @@ jobs:
             });
         });
 
-        it('parses a complete ssh url with rootDir', () => {
+        it('parses a ssh url with rootDir passed in', () => {
             githubMock.repos.get.resolves({ data: repoData });
 
             return scm.parseUrl({
@@ -1540,6 +1540,22 @@ jobs:
                 assert.calledWith(githubMock.repos.get, sinon.match(repoInfo));
                 assert.calledWith(githubMock.repos.get, sinon.match({
                     branch: 'boat'
+                }));
+            });
+        });
+
+        it('parses a complete ssh url with rootDir', () => {
+            githubMock.repos.get.resolves({ data: repoData });
+
+            return scm.parseUrl({
+                checkoutUrl: 'git@github.com:iAm/theCaptain.git#boat:path/to/water',
+                token,
+                rootDir: ''
+            }).then((result) => {
+                assert.strictEqual(result, 'github.com:8675309:boat:path/to/water');
+                assert.calledWith(githubMock.repos.get, sinon.match(repoInfo));
+                assert.calledWith(githubMock.repos.get, sinon.match({
+                    rootDir: 'path/to/water'
                 }));
             });
         });


### PR DESCRIPTION
## Context

Would be nice if childPipelines could be sourced from somewhere other than checkout root dir.

## Objective

This PR reads rootDir from checkoutUrl.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2398

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
