### PR TITLE
feat: Allow PENDING status for GitHub PR 

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,14 +32,16 @@ const POLLING_MAX_ATTEMPT = 10;
 const STATE_MAP = {
     SUCCESS: 'success',
     RUNNING: 'pending',
-    QUEUED: 'pending'
+    QUEUED: 'pending',
+    PENDING: 'pending'
 };
 const DESCRIPTION_MAP = {
     SUCCESS: 'Everything looks good!',
     FAILURE: 'Did not work as expected.',
     ABORTED: 'Aborted mid-flight',
     RUNNING: 'Testing your code...',
-    QUEUED: 'Looking for a place to park...'
+    QUEUED: 'Looking for a place to park...',
+    PENDING: 'Looks good but incomplete.'
 };
 const PERMITTED_RELEASE_EVENT = [
     'published'


### PR DESCRIPTION
## Context

Users might want to report on a PENDING status for GitHub PR.

## Objective

This PR adds pending key for the PR status and description map.

## References

[fix: Allow pending status for GitHub PR meta status check #496
](https://github.com/screwdriver-cd/models/pull/496)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
