### PR TITLE
fix: Exclude unnecessary retries for checking PR mergeability

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,7 +286,7 @@ class GithubScm extends Scm {
         try {
             const pullRequestInfo = await this.getPrInfo({ scmUri, token, prNum });
 
-            if (pullRequestInfo.mergeable !== null) {
+            if (pullRequestInfo.mergeable !== null && pullRequestInfo.mergeable !== undefined) {
                 return { success: pullRequestInfo.mergeable, pullRequestInfo };
             }
             if (count >= POLLING_MAX_ATTEMPT - 1) {

--- a/index.js
+++ b/index.js
@@ -286,8 +286,8 @@ class GithubScm extends Scm {
         try {
             const pullRequestInfo = await this.getPrInfo({ scmUri, token, prNum });
 
-            if (pullRequestInfo.mergeable) {
-                return { success: true, pullRequestInfo };
+            if (pullRequestInfo.mergeable !== null) {
+                return { success: pullRequestInfo.mergeable, pullRequestInfo };
             }
             if (count >= POLLING_MAX_ATTEMPT - 1) {
                 logger.warn(`Computing mergerbility did not finish. scmUri: ${scmUri}, prNum: ${prNum}`);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If PR is not mergeable, `waitPrMergeability` method will retry `POLLING_MAX_ATTEMPT` times.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fix `waitPrMergeability` to return false without retrying if it turns out that a PR is not mergeable.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[This document](https://docs.github.com/en/rest/reference/pulls#get-a-pull-request) says that `pullRequestInfo.mergeable` can be `true`, `false`, or `null`.
If `mergeable` is `true`, then the PR is mergeable.
If `mergeable` is `false`, then the PR is NOT mergeable.
If `mergeable` is `null`, then the mergeability is being calculated.

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
