### PR TITLE
Fix: Unauthorized users can be allowed to view the private pipeline if the logged-in user's scmContext and the pipeline's scmContext are different (scm-github)

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,6 +227,11 @@ class GithubScm extends Scm {
             privateRepo = scmRepo.privateRepo || false;
         } else {
             try {
+                if (scmHost !== this.config.gheHost) {
+                    throw new Error(
+                        `Pipeline's scmHost ${scmHost} does not match with user's scmHost ${this.config.gheHost}`
+                    );
+                }
                 // https://github.com/octokit/rest.js/issues/163
                 const repo = await this.breaker.runCommand({
                     scopeType: 'request',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If multiple ghe instances are available from Screwdriver.cd, you may be able to see private pipelines that shouldn't be visible.

For example, if you have the following ghe instances:
- ghe-a
- ghe-b

Create a private pipeline `private-1` on `ghe-b`. In this case, the user logged in to the Screwdriver in the context of `ghe-b` will not be able to view `private-1`. This access is 404 because this user's privileges cannot look up the target pipeline.

The problem occurs when the user's login context is `ghe-a`. The` lookUpScmUri` function does not take into account the pipeline's scmContext at all and uses the user's login context to get the repository information. Therefore, although the repository id is the same as `private-1`, the destination is `ghe-a`. Since this meaningless repository is public, you can see what you shouldn't be able to see after passing authentication.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Check the user's login context just before hitting the API to look up GHE. Accessing a GHE instance in a different context is meaningless and throws an error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
PR for scm-gitlab
https://github.com/screwdriver-cd/scm-gitlab/pull/46

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
