### PR TITLE
fix: publish error

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
     "ssh-keygen": "^0.5.0"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I recently modified scm-git (hab | lab) but got an error when publishing.

https://cd.screwdriver.cd/pipelines/8/builds/749932/steps/publish
https://cd.screwdriver.cd/pipelines/1653/builds/749929/steps/publish

It seems that the noop plugin is no longer needed due to the version upgrade of semantic-release, so the noop plugin will be deleted in this PR.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
scm-git(hub|lab) is published.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/aws-producer-service/pull/4

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
