### PR TITLE
fix: error occurs on open source

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,9 @@ class GithubScm extends Scm {
             privateRepo = scmRepo.privateRepo || false;
         } else {
             try {
-                if (scmHost !== this.config.gheHost) {
+                const myHost = this.config.gheHost || 'github.com';
+
+                if (scmHost !== myHost) {
                     throw new Error(
                         `Pipeline's scmHost ${scmHost} does not match with user's scmHost ${this.config.gheHost}`
                     );

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -676,6 +676,47 @@ describe('index', function() {
                 });
         });
 
+        it('looks up a repo by github.com as default for open source using', () => {
+            const testResponse = {
+                full_name: 'screwdriver-cd/models',
+                private: false
+            };
+
+            githubMock.request.resolves({ data: testResponse });
+
+            scm = new GithubScm({
+                fusebox: {
+                    retry: {
+                        minTimeout: 1
+                    }
+                },
+                readOnly: {},
+                oauthClientId: 'abcdefg',
+                oauthClientSecret: 'hijklmno',
+                secret: 'somesecret',
+                commentUserToken: 'sometoken',
+                gheHost: undefined
+            });
+
+            return scm
+                .lookupScmUri({
+                    scmUri,
+                    token: 'sometoken'
+                })
+                .then(repoData => {
+                    assert.deepEqual(repoData, {
+                        branch: 'targetBranch',
+                        host: 'github.com',
+                        repo: 'models',
+                        owner: 'screwdriver-cd',
+                        rootDir: '',
+                        privateRepo: false
+                    });
+
+                    assert.calledWith(githubMock.request, 'GET /repositories/:id', { id: '23498' });
+                });
+        });
+
         it('looks up a repo by SCM URI with rootDir', () => {
             const testResponse = {
                 full_name: 'screwdriver-cd/models',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fixed a bug when scmContext was mismatched in the following PR.
https://github.com/screwdriver-cd/scm-github/pull/194

However, as shown below, an error has occurred when using OpenSource.
https://github.com/screwdriver-cd/scm-github/pull/194#discussion_r750796270

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
When using OpenSource, `this.config.gheHost` is` undefined`, so set `github.com` as the default value.

Since gitlab has default values ​​set when the object is created, no modification is necessary.
https://github.com/screwdriver-cd/scm-gitlab/blob/e22370a28b41a8236866996ca31a96e978b8b14c/index.js#L135

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.