### PR TITLE
feat(2676): Support passing in full path for getFile [1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
-    "eslint": "^7.5.0",
+    "chai": "^4.3.6",
+    "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
     "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
@@ -43,14 +43,14 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@hapi/hoek": "^9.2.0",
-    "@octokit/rest": "^18.6.7",
+    "@hapi/hoek": "^9.2.1",
+    "@octokit/rest": "^18.12.0",
     "@octokit/webhooks": "^7.24.3",
-    "circuit-fuses": "^4.0.6",
-    "joi": "^17.4.0",
-    "screwdriver-data-schema": "^21.6.1",
-    "screwdriver-logger": "^1.0.2",
-    "screwdriver-scm-base": "^7.2.1",
+    "circuit-fuses": "^4.1.2",
+    "joi": "^17.6.0",
+    "screwdriver-data-schema": "^21.21.1",
+    "screwdriver-logger": "^1.1.0",
+    "screwdriver-scm-base": "^7.4.0",
     "ssh-keygen": "^0.5.0"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1244,6 +1244,26 @@ jobs:
                 });
         });
 
+        it('promises to get content when only full path is passed', () => {
+            githubMock.repos.getContent.resolves({ data: returnData });
+
+            return scm
+                .getFile({
+                    scmUri: 'github.com:146:master:src/app/component',
+                    path: 'git@github.com:screwdriver-cd/scm-github.git:path/to/a/file.yaml',
+                    token: 'somerandomtoken'
+                })
+                .then(data => {
+                    assert.deepEqual(data, expectedYaml);
+                    assert.calledWith(githubMock.repos.getContent, {
+                        owner: 'screwdriver-cd',
+                        repo: 'scm-github',
+                        path: 'path/to/a/file.yaml',
+                        ref: 'main'
+                    });
+                });
+        });
+
         it('promises to get empty content when file is not found', () => {
             const err = new Error('githubError');
 


### PR DESCRIPTION
## Context

In order to support getting provider config dynamically in screwdriver.yaml, we need to be able to pass in the full path to getFile instead of the scmUri, etc.

## Objective

This PR changes getFile method to allow using full path to get repo owner, name, branch, etc info.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2676
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
