### PR TITLE
[2]feat(2695): Does not overwrite PR comment that from other PR job

### DIFF
--- a/index.js
+++ b/index.js
@@ -1696,7 +1696,7 @@ class GithubScm extends Scm {
      * @param  {String}     config.token       Service token to authenticate with Github
      * @return {Promise}                       Resolves when complete
      */
-    async _addPrComment({ comment, prNum, scmUri, token }) {
+    async _addPrComment({ comment, jobName, prNum, scmUri, token, pipelineId }) {
         const scmInfo = await this.lookupScmUri({
             scmUri,
             token
@@ -1705,7 +1705,14 @@ class GithubScm extends Scm {
         const prComments = await this.prComments(scmInfo, prNum, token);
 
         if (prComments) {
-            const botComment = prComments.comments.find(commentObj => commentObj.user.login === this.config.username);
+            const botComment = prComments.comments.find(
+                commentObj =>
+                    commentObj.user.login === this.config.username &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/) &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[1] ===
+                        pipelineId.toString() &&
+                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[2] === jobName
+            );
 
             if (botComment) {
                 try {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const joi = require('joi');
 const keygen = require('ssh-keygen');
 const schema = require('screwdriver-data-schema');
 const CHECKOUT_URL_REGEX = schema.config.regex.CHECKOUT_URL;
+const PR_COMMENTS_REGEX = /^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/;
 const Scm = require('screwdriver-scm-base');
 const logger = require('screwdriver-logger');
 const DEFAULT_AUTHOR = {
@@ -1708,10 +1709,9 @@ class GithubScm extends Scm {
             const botComment = prComments.comments.find(
                 commentObj =>
                     commentObj.user.login === this.config.username &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/) &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[1] ===
-                        pipelineId.toString() &&
-                    commentObj.body.split(/\n/)[0].match(/^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/)[2] === jobName
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX) &&
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[1] === pipelineId.toString() &&
+                    commentObj.body.split(/\n/)[0].match(PR_COMMENTS_REGEX)[2] === jobName
             );
 
             if (botComment) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2815,10 +2815,14 @@ jobs:
     describe('_addPrComment', () => {
         const scmUri = 'github.com:111:branchName';
         const comment = 'this was a great PR';
+        const jobName = 'main';
+        const pipelineId = '123456';
         const config = {
             scmUri,
             token: 'token',
             prNum: 1,
+            jobName,
+            pipelineId,
             comment
         };
 


### PR DESCRIPTION
## Context
If multiple jobs have PR comments, the later job's comment overwrites the earlier job's comment.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We change so that PR comments are only edited by the same job in the same pipeline.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://docs.github.com/ja/rest/issues/comments#list-issue-comments
https://github.com/screwdriver-cd/screwdriver/issues/2695
Reflect the following PRs before reflecting this.
- https://github.com/screwdriver-cd/data-schema/pull/489
- https://github.com/screwdriver-cd/models/pull/543
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
