### PR TITLE
Fix(2753): Get open pull requests - override the default limit (30) to return up to 100

### DIFF
--- a/index.js
+++ b/index.js
@@ -877,7 +877,8 @@ class GithubScm extends Scm {
                 params: {
                     owner,
                     repo,
-                    state: 'open'
+                    state: 'open',
+                    per_page: 100
                 }
             });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2683,7 +2683,8 @@ jobs:
                 assert.calledWith(githubMock.pulls.list, {
                     owner: 'repoOwner',
                     repo: 'repoName',
-                    state: 'open'
+                    state: 'open',
+                    per_page: 100
                 });
             });
         });


### PR DESCRIPTION
## Context

Github API to fetch pull requests has default page size of 30
https://docs.github.com/en/rest/overview/resources-in-the-rest-api#pagination

This affects the Pull Request Sync workflow when there are more that 30 open pull requests.
This flow assumes that `getOpenedPRs()` API would return complete list of open pull requests for the specified repo.
When only 30 PRs are returned, the sync flow treats other open PRs are closed and archive the jobs related to them.
Thus preventing any new events/builds against them.

**Short term fix:**
Override the default page size to the maximum allowed size (100)

**Long term fix:**
Iterate over all the pages, consolidate and return the items from all the pages. Need more analysis to see how feasible this would be or find alternative approach.

## Objective
This PR delivers the short term fix i.e. increase the default page size to 100.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2753

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
