### PR TITLE
fix(2734): Builds cannot be started if a pipeline has more than 5 invalid admins

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,19 @@ class GithubScm extends Scm {
             this.octokitConfig.baseUrl = `${this.config.gheProtocol}://${this.config.gheHost}/api/v3`;
         }
 
+        let breakerOption = this.config.fusebox.breaker;
+
+        if (breakerOption) {
+            breakerOption.errorFn = function(err) {
+                return !(err.statusCode >= 400 && err.statusCode < 500);
+            };
+        } else {
+            breakerOption = {
+                errorFn(err) {
+                    return !(err.statusCode >= 400 && err.statusCode < 500);
+                }
+            };
+        }
         // eslint-disable-next-line no-underscore-dangle
         this.breaker = new Breaker(this._githubCommand.bind(this), {
             // Do not retry when there is a 4XX error

--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ class GithubScm extends Scm {
             // Do not retry when there is a 4XX error
             shouldRetry: err => err && err.statusCode && !(err.statusCode >= 400 && err.statusCode < 500),
             retry: this.config.fusebox.retry,
-            breaker: this.config.fusebox.breaker
+            breaker: breakerOption
         });
     }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Improve the following Issue.
https://github.com/screwdriver-cd/screwdriver/issues/2734


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In this PR, change the Circuit Breaker so that it is not Open even if a 4XX response code is returned from the GitHub

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2734

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
