### PR TITLE
fix(2892): normalize the type of GitHub user id to String

### DIFF
--- a/index.js
+++ b/index.js
@@ -1260,7 +1260,7 @@ class GithubScm extends Scm {
             const name = user.data.name || user.data.login;
 
             return {
-                id: user.data.id,
+                id: user.data.id.toString(),
                 avatar: user.data.avatar_url,
                 name,
                 username: user.data.login,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2010,7 +2010,7 @@ jobs:
                 })
                 .then(data => {
                     assert.deepEqual(data, {
-                        id: 2042,
+                        id: '2042',
                         avatar: 'https://avatars.githubusercontent.com/u/2042?v=3',
                         name: 'Klark Cent',
                         url: `https://github.com/${username}`,
@@ -2041,7 +2041,7 @@ jobs:
                 })
                 .then(data => {
                     assert.deepEqual(data, {
-                        id: 2042,
+                        id: '2042',
                         avatar: 'https://avatars.githubusercontent.com/u/2042?v=3',
                         name: username,
                         url: `https://github.com/${username}`,
@@ -2141,7 +2141,7 @@ jobs:
                 .then(data => {
                     assert.deepEqual(data, {
                         author: {
-                            id: 1234567,
+                            id: '1234567',
                             avatar: 'https://avatars.githubusercontent.com/u/1234567?v=3',
                             name: 'Batman Wayne',
                             url: 'https://internal-ghe.mycompany.com/notbrucewayne',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up of PR https://github.com/screwdriver-cd/scm-github/pull/216

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR normalize the type of GitHub user id to String.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2892#issuecomment-1602452632

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
