### PR TITLE
fix(2952): Allow colon to be used in root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,9 @@ class GithubScm extends Scm {
      * @return {Promise}                        Resolves to an object containing repository-related information
      */
     async lookupScmUri({ scmUri, scmRepo, token }) {
-        const [scmHost, scmId, scmBranch, rootDir] = scmUri.split(':');
+        const parts = scmUri.split(':');
+        const [scmHost, scmId, scmBranch, ...rootDirParts] = parts;
+        const rootDir = rootDirParts.join(':');
 
         let repoFullName;
         let defaultBranch;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -385,7 +385,7 @@ describe('index', function() {
         });
 
         it('promises to get the checkout command when rootDir with special characters is passed in', () => {
-            config.rootDir = '!"#$%&\'()-=|@`{;+]},<.>　🚗';
+            config.rootDir = '!"#$%&\'()-=|@`{:;+]},<.>　🚗';
 
             return scm.getCheckoutCommand(config).then(command => {
                 assert.deepEqual(command, testSpecialCharacterRootDirCommands);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Pipeline cannot be created correctly if rootDirectory contains a colon.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fix to correctly parse rootDirectory even if it contains a colon.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2952

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
