### PR TITLE
fix: upgrade octokit

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const Breaker = require('circuit-fuses').breaker;
 const { Octokit } = require('@octokit/rest');
-const { verify } = require('@octokit/webhooks');
+const { verify } = require('@octokit/webhooks-methods');
 const hoek = require('@hapi/hoek');
 const Path = require('path');
 const joi = require('joi');
@@ -1476,7 +1476,7 @@ class GithubScm extends Scm {
         }
 
         // eslint-disable-next-line no-underscore-dangle
-        if (!verify(this.config.secret, webhookPayload, signature)) {
+        if (!(await verify(this.config.secret, JSON.stringify(webhookPayload), signature))) {
             throwError('Invalid x-hub-signature');
         }
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.1",
-    "@octokit/rest": "^19.0.5",
-    "@octokit/webhooks": "^7.24.3",
+    "@octokit/rest": "^20.0.2",
+    "@octokit/webhooks-methods": "^4.0.0",
     "circuit-fuses": "^5.0.0",
     "joi": "^17.7.0",
     "screwdriver-data-schema": "^22.0.1",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Vulnerability discovered in `@octokit/webhooks`.
Reference: https://github.com/screwdriver-cd/scm-github/pull/221.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

`@octokit/webhooks` no longer exports verify methods in version 9, so we are moving to `@octokit/webhooks-methods`.
https://github.com/octokit/webhooks.js/releases/tag/v9.0.0

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
