### PR TITLE
feat: add scopes for GQL query

### DIFF
--- a/index.js
+++ b/index.js
@@ -1675,6 +1675,12 @@ class GithubScm extends Scm {
             };
         }
 
+        if (this.config.gheCloud) {
+            const oauthScope = bellConfig.scope;
+
+            bellConfig.scope = oauthScope.concat('read:enterprise', 'read:user');
+        }
+
         return { [scmContext]: bellConfig };
     }
 
@@ -1993,7 +1999,6 @@ class GithubScm extends Scm {
      * Returns if a user is an enterprise user
      * @param {Object} config  The configuration object
      * @param {String} config.token  The token used to authenticate to the SCM
-     * @param {String} config.slug   The slug of the enterprise
      * @param {String} config.login  The login of the Github user
      * @returns Boolean
      */
@@ -2001,6 +2006,9 @@ class GithubScm extends Scm {
         if (!this.scmGithubGQL) {
             return false;
         }
+
+        config.slug = this.config.gheCloudSlug;
+
         const user = await this.scmGithubGQL.getEnterpriseUserAccount(config);
 
         return !!user && user.type === ENTERPRISE_USER;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2507,6 +2507,30 @@ jobs:
                 });
             });
         });
+
+        it('adds enterprise scope to support GraphQL queries', () => {
+            scm = new GithubScm({
+                oauthClientId: 'abcdefg',
+                oauthClientSecret: 'hijklmno',
+                secret: 'somesecret',
+                gheCloud: true,
+                gheCloudSlug: 'ghe-slug'
+            });
+
+            return scm.getBellConfiguration().then(config => {
+                assert.deepEqual(config, {
+                    'github:github.com': {
+                        clientId: 'abcdefg',
+                        clientSecret: 'hijklmno',
+                        forceHttps: false,
+                        isSecure: false,
+                        provider: 'github',
+                        cookie: 'github-github.com',
+                        scope: ['admin:repo_hook', 'read:org', 'repo:status', 'read:enterprise', 'read:user']
+                    }
+                });
+            });
+        });
     });
 
     describe('addWebhook', () => {
@@ -3381,6 +3405,7 @@ jobs:
                 commentUserToken: 'sometoken',
                 gheHost: 'github.com',
                 gheCloud: true,
+                gheCloudSlug: slug
 
             });
 
@@ -3390,7 +3415,6 @@ jobs:
         it('returns true if user is an enterprise user', async () => {
             config = {
                 login,
-                slug,
                 token
             };
 
@@ -3403,7 +3427,10 @@ jobs:
             const result = await scm._isEnterpriseUser(config);
 
             assert.strictEqual(result, true);
-            assert.calledWith(scm.scmGithubGQL.getEnterpriseUserAccount, config);
+            assert.calledWith(scm.scmGithubGQL.getEnterpriseUserAccount, {
+                ...config,
+                slug
+            });
         })
 
         it('returns false if user is not an enterprise user', async () => {
@@ -3413,7 +3440,10 @@ jobs:
             const result = await scm._isEnterpriseUser(config);
 
             assert.strictEqual(result, false);
-            assert.calledWith(scm.scmGithubGQL.getEnterpriseUserAccount, config);
+            assert.calledWith(scm.scmGithubGQL.getEnterpriseUserAccount, {
+                ...config,
+                slug
+            });
         });
     });
 });


### PR DESCRIPTION
## Context

Github GQL queries need additional scopes to query an enterprise 

## Objective

This PR adds additional scopes to the oAuth token for running GQL queries.

## References

https://docs.github.com/en/enterprise-cloud@latest/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#requested-scopes-and-granted-scopes

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
