### PR TITLE
feat: allow github cloud context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ The class has a variety of knobs to tweak when interacting with GitHub.
 | config.fusebox | Object | {} | [Circuit Breaker configuration][circuitbreaker] |
 | config.secret | String | | Secret to validate the signature of webhook events |
 | config.privateRepo | Boolean | false | Request 'repo' scope, which allows read/write access for public & private repos
-
+| config.gheCloud | Boolean |  false | Flag set to true if using Github Enterprise Cloud |
+| [config.gheCloudSlug] | String | null | The Github Enterprise Cloud Slug |
+| [config.gheCloudCookie] | String| null |   The Github Enterprise Cloud Cookie name |
+| [config.gheCloudContext] | String | null |  The Github Enterprise Cloud scm context |
+| config.githubGraphQLUrl | String  | https://api.github.com/graphql |     GraphQL endpoint for GitHub  |
+    
 ```js
 const scm = new GithubScm({
     oauthClientId: 'abcdef',

--- a/index.js
+++ b/index.js
@@ -195,67 +195,33 @@ class GithubScm extends Scm {
             joi
                 .object()
                 .keys({
-                    privateRepo: joi
-                        .boolean()
-                        .optional()
-                        .default(false),
-                    gheProtocol: joi
-                        .string()
-                        .optional()
-                        .default('https'),
-                    gheHost: joi
-                        .string()
-                        .optional()
-                        .description('GitHub Enterprise host'),
-                    username: joi
-                        .string()
-                        .optional()
-                        .default('sd-buildbot'),
-                    email: joi
-                        .string()
-                        .optional()
-                        .default('dev-null@screwdriver.cd'),
-                    commentUserToken: joi
-                        .string()
-                        .optional()
-                        .description('Token for PR comments'),
-                    autoDeployKeyGeneration: joi
-                        .boolean()
-                        .optional()
-                        .default(false),
+                    privateRepo: joi.boolean().optional().default(false),
+                    gheProtocol: joi.string().optional().default('https'),
+                    gheHost: joi.string().optional().description('GitHub Enterprise host'),
+                    username: joi.string().optional().default('sd-buildbot'),
+                    email: joi.string().optional().default('dev-null@screwdriver.cd'),
+                    commentUserToken: joi.string().optional().description('Token for PR comments'),
+                    autoDeployKeyGeneration: joi.boolean().optional().default(false),
                     readOnly: joi
                         .object()
                         .keys({
                             enabled: joi.boolean().optional(),
                             username: joi.string().optional(),
                             accessToken: joi.string().optional(),
-                            cloneType: joi
-                                .string()
-                                .valid('https', 'ssh')
-                                .optional()
-                                .default('https')
+                            cloneType: joi.string().valid('https', 'ssh').optional().default('https')
                         })
                         .optional()
                         .default({}),
-                    https: joi
-                        .boolean()
-                        .optional()
-                        .default(false),
+                    https: joi.boolean().optional().default(false),
                     oauthClientId: joi.string().required(),
                     oauthClientSecret: joi.string().required(),
                     fusebox: joi.object().default({}),
                     secret: joi.string().required(),
-                    gheCloud: joi
-                        .boolean()
-                        .optional()
-                        .default(false),
+                    gheCloud: joi.boolean().optional().default(false),
                     gheCloudSlug: joi.string().optional(),
                     gheCloudCookie: joi.string().optional(),
                     gheCloudContext: joi.string().optional(),
-                    githubGraphQLUrl: joi
-                        .string()
-                        .optional()
-                        .default('https://api.github.com/graphql')
+                    githubGraphQLUrl: joi.string().optional().default('https://api.github.com/graphql')
                 })
                 .unknown(true),
             'Invalid config for GitHub'
@@ -286,8 +252,8 @@ class GithubScm extends Scm {
 
         this.scmGithubGQL = config.gheCloud
             ? new ScmGithubGraphQL({
-                graphqlUrl: this.config.githubGraphQLUrl
-            })
+                  graphqlUrl: this.config.githubGraphQLUrl
+              })
             : null;
     }
 
@@ -700,8 +666,8 @@ class GithubScm extends Scm {
         command.push(
             // eslint-disable-next-line no-template-curly-in-string
             "export SD_GIT_WRAPPER=\"$(if [ `uname` = 'Darwin' ] || [ ${SD_HAB_ENABLED:-false} = 'false' ]; " +
-            "then echo 'eval'; " +
-            "else echo 'sd-step exec core/git'; fi)\""
+                "then echo 'eval'; " +
+                "else echo 'sd-step exec core/git'; fi)\""
         );
 
         command.push('if [ ! -z $SD_SCM_DEPLOY_KEY ]; then export SCM_CLONE_TYPE=ssh; fi');
@@ -715,17 +681,17 @@ class GithubScm extends Scm {
             } else {
                 command.push(
                     'if [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
-                    `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +
-                    `else export SCM_URL=https://${checkoutUrl}; fi`
+                        `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +
+                        `else export SCM_URL=https://${checkoutUrl}; fi`
                 );
             }
         } else {
             command.push(
                 'if [ ! -z $SCM_CLONE_TYPE ] && [ $SCM_CLONE_TYPE = ssh ]; ' +
-                `then export SCM_URL=${sshCheckoutUrl}; ` +
-                'elif [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
-                `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +
-                `else export SCM_URL=https://${checkoutUrl}; fi`
+                    `then export SCM_URL=${sshCheckoutUrl}; ` +
+                    'elif [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
+                    `then export SCM_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@${checkoutUrl}; ` +
+                    `else export SCM_URL=https://${checkoutUrl}; fi`
             );
         }
         command.push('export GIT_URL=$SCM_URL.git');
@@ -739,10 +705,10 @@ class GithubScm extends Scm {
         // 4. Add SCM host as a known host by adding config to ~/.ssh/config
         command.push(
             'if [ ! -z $SD_SCM_DEPLOY_KEY ] && [ $SCM_CLONE_TYPE = ssh ]; ' +
-            'then ' +
-            'echo $SD_SCM_DEPLOY_KEY | base64 -d > /tmp/git_key && echo "" >> /tmp/git_key && ' +
-            'chmod 600 /tmp/git_key && export GIT_SSH_COMMAND="ssh -i /tmp/git_key" && ' +
-            `mkdir -p ~/.ssh/ && printf "%s\n" "${gitConfigB64}" | base64 -d >> ~/.ssh/config; fi`
+                'then ' +
+                'echo $SD_SCM_DEPLOY_KEY | base64 -d > /tmp/git_key && echo "" >> /tmp/git_key && ' +
+                'chmod 600 /tmp/git_key && export GIT_SSH_COMMAND="ssh -i /tmp/git_key" && ' +
+                `mkdir -p ~/.ssh/ && printf "%s\n" "${gitConfigB64}" | base64 -d >> ~/.ssh/config; fi`
         );
 
         // Set config
@@ -778,11 +744,11 @@ class GithubScm extends Scm {
 
             command.push(
                 'if [ ! -z $SCM_CLONE_TYPE ] && [ $SCM_CLONE_TYPE = ssh ]; ' +
-                `then export CONFIG_URL=${parentSshCheckoutUrl}; ` +
-                'elif [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
-                'then export CONFIG_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@' +
-                `${parentCheckoutUrl}; ` +
-                `else export CONFIG_URL=https://${parentCheckoutUrl}; fi`
+                    `then export CONFIG_URL=${parentSshCheckoutUrl}; ` +
+                    'elif [ ! -z $SCM_USERNAME ] && [ ! -z $SCM_ACCESS_TOKEN ]; ' +
+                    'then export CONFIG_URL=https://$SCM_USERNAME:$SCM_ACCESS_TOKEN@' +
+                    `${parentCheckoutUrl}; ` +
+                    `else export CONFIG_URL=https://${parentCheckoutUrl}; fi`
             );
 
             command.push(`export SD_CONFIG_DIR=${externalConfigDir}`);
@@ -790,12 +756,14 @@ class GithubScm extends Scm {
             // Git clone
             command.push(`echo 'Cloning external config repo ${parentCheckoutUrl}'`);
             command.push(
-                `${'if [ ! -z $GIT_SHALLOW_CLONE ] && [ $GIT_SHALLOW_CLONE = false ]; ' +
-                'then $SD_GIT_WRAPPER ' +
-                `"git clone --recursive --quiet --progress --branch '${escapedParentBranch}' ` +
-                '$CONFIG_URL $SD_CONFIG_DIR"; '}${shallowCloneCmd}` +
-                `--recursive --quiet --progress --branch '${escapedParentBranch}' ` +
-                '$CONFIG_URL $SD_CONFIG_DIR"; fi'
+                `${
+                    'if [ ! -z $GIT_SHALLOW_CLONE ] && [ $GIT_SHALLOW_CLONE = false ]; ' +
+                    'then $SD_GIT_WRAPPER ' +
+                    `"git clone --recursive --quiet --progress --branch '${escapedParentBranch}' ` +
+                    '$CONFIG_URL $SD_CONFIG_DIR"; '
+                }${shallowCloneCmd}` +
+                    `--recursive --quiet --progress --branch '${escapedParentBranch}' ` +
+                    '$CONFIG_URL $SD_CONFIG_DIR"; fi'
             );
 
             // Reset to SHA
@@ -841,19 +809,21 @@ class GithubScm extends Scm {
             // Export $SD_SOURCE_DIR to source repo path and cd into it
             command.push(
                 `if [ $(cat ${sourcePath}) != "." ]; ` +
-                `then export SD_SOURCE_DIR=$SD_SOURCE_DIR/$(cat ${sourcePath}); fi`
+                    `then export SD_SOURCE_DIR=$SD_SOURCE_DIR/$(cat ${sourcePath}); fi`
             );
             command.push('cd $SD_SOURCE_DIR');
         } else {
             // Git clone
             command.push(`echo 'Cloning ${checkoutUrl}, on branch ${singleQuoteEscapedBranch}'`);
             command.push(
-                `${'if [ ! -z $GIT_SHALLOW_CLONE ] && [ $GIT_SHALLOW_CLONE = false ]; ' +
-                'then $SD_GIT_WRAPPER ' +
-                `"git clone --recursive --quiet --progress --branch '${doubleQuoteEscapedBranch}' ` +
-                '$SCM_URL $SD_CHECKOUT_DIR_FINAL"; '}${shallowCloneCmd}` +
-                `--recursive --quiet --progress --branch '${doubleQuoteEscapedBranch}' ` +
-                '$SCM_URL $SD_CHECKOUT_DIR_FINAL"; fi'
+                `${
+                    'if [ ! -z $GIT_SHALLOW_CLONE ] && [ $GIT_SHALLOW_CLONE = false ]; ' +
+                    'then $SD_GIT_WRAPPER ' +
+                    `"git clone --recursive --quiet --progress --branch '${doubleQuoteEscapedBranch}' ` +
+                    '$SCM_URL $SD_CHECKOUT_DIR_FINAL"; '
+                }${shallowCloneCmd}` +
+                    `--recursive --quiet --progress --branch '${doubleQuoteEscapedBranch}' ` +
+                    '$SCM_URL $SD_CHECKOUT_DIR_FINAL"; fi'
             );
 
             // Reset to SHA
@@ -1713,7 +1683,12 @@ class GithubScm extends Scm {
         const scmContexts = this._getScmContexts();
         const scmContext = scmContexts[0];
         const scope = ['admin:repo_hook', 'read:org', 'repo:status'];
-        const cookie = this.config.gheHost ? `github-${this.config.gheHost}` : this.config.gheCloudCookie ?? 'github-github.com';
+        let cookie = this.config.gheHost ? `github-${this.config.gheHost}` : 'github-github.com';
+
+        if (this.config.gheCloudCookie) {
+            cookie = this.config.gheCloudCookie;
+        }
+
         const bellConfig = {
             provider: 'github',
             cookie,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "eslint": "^7.32.0",
-    "eslint-config-screwdriver": "^5.0.1",
+    "eslint-config-screwdriver": "^7.0.0",
     "mocha": "^8.4.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,7 +44,7 @@ sinon.assert.expose(assert, {
     prefix: ''
 });
 
-describe('index', function() {
+describe('index', function () {
     // Time not important. Only life important
     this.timeout(5000);
 
@@ -109,7 +109,7 @@ describe('index', function() {
         };
 
         class GithubGqlMock {
-            getEnterpriseUserAccount() {}
+            getEnterpriseUserAccount() { }
         }
 
         mockery.registerMock('@octokit/rest', githubMockClass);
@@ -713,7 +713,7 @@ describe('index', function() {
                     assert.calledWith(
                         winstonMock.info,
                         "User's account suspended for github.com:359478:master, " +
-                            'it will be removed from pipeline admins.'
+                        'it will be removed from pipeline admins.'
                     );
                 })
                 .catch(() => {
@@ -2666,6 +2666,32 @@ jobs:
             });
         });
 
+        it('returns configuration for github enterprise cloud', () => {
+            scm = new GithubScm({
+                oauthClientId: 'abcdefg',
+                oauthClientSecret: 'defghijk',
+                gheCloud: true,
+                gheCloudSlug: 'ghe-slug',
+                gheCloudCookie: 'github-example-github.com',
+                gheCloudContext: 'github:example.github.com',
+                secret: 'somesecret'
+            });
+
+            return scm.getBellConfiguration().then(config => {
+                assert.deepEqual(config, {
+                    'github:example.github.com': {
+                        clientId: 'abcdefg',
+                        clientSecret: 'defghijk',                       
+                        forceHttps: false,
+                        isSecure: false,
+                        provider: 'github',
+                        cookie: 'github-example-github.com',
+                        scope: ['admin:repo_hook', 'read:org', 'repo:status', "read:enterprise", "read:user"]
+                    }
+                });
+            });
+        });
+
         it('add repo scope to support private repo', () => {
             scm = new GithubScm({
                 oauthClientId: 'abcdefg',
@@ -3385,6 +3411,22 @@ jobs:
             const result = scm.getScmContexts();
 
             return assert.deepEqual(result, ['github:github.screwdriver.cd']);
+        });
+
+        it('returns a scmContext for github enterprise cloud', () => {
+            scm = new GithubScm({
+                oauthClientId: 'abcdefg',
+                oauthClientSecret: 'hijklmno',
+                gheCloud: true,
+                gheCloudSlug: 'ghe-slug',
+                gheCloudCookie: 'github-example-github.com',
+                gheCloudContext: 'github:example.github.com',
+                secret: 'somesecret'
+            });
+
+            const result = scm.getScmContexts();
+
+            return assert.deepEqual(result, ['github:example.github.com']);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,7 +109,7 @@ describe('index', function () {
         };
 
         class GithubGqlMock {
-            getEnterpriseUserAccount() { }
+            getEnterpriseUserAccount() {}
         }
 
         mockery.registerMock('@octokit/rest', githubMockClass);
@@ -590,9 +590,7 @@ describe('index', function () {
         });
 
         it('throws error when getRef API returned unexpected type', () => {
-            const type = Math.random()
-                .toString(36)
-                .slice(-8);
+            const type = Math.random().toString(36).slice(-8);
             const err = `Cannot handle ${type} type`;
 
             githubMock.git.getRef.resolves({ data: { object: { sha: tagSha, type } } });
@@ -713,7 +711,7 @@ describe('index', function () {
                     assert.calledWith(
                         winstonMock.info,
                         "User's account suspended for github.com:359478:master, " +
-                        'it will be removed from pipeline admins.'
+                            'it will be removed from pipeline admins.'
                     );
                 })
                 .catch(() => {
@@ -2681,12 +2679,12 @@ jobs:
                 assert.deepEqual(config, {
                     'github:example.github.com': {
                         clientId: 'abcdefg',
-                        clientSecret: 'defghijk',                       
+                        clientSecret: 'defghijk',
                         forceHttps: false,
                         isSecure: false,
                         provider: 'github',
                         cookie: 'github-example-github.com',
-                        scope: ['admin:repo_hook', 'read:org', 'repo:status', "read:enterprise", "read:user"]
+                        scope: ['admin:repo_hook', 'read:org', 'repo:status', 'read:enterprise', 'read:user']
                     }
                 });
             });


### PR DESCRIPTION
## Context

The design of `scm-github` currently supports a single OAuth app for non GHE host (github.com), but with the addition of github cloud we can have multiple enterprise github cloud accounts with same url i.e. https://github.com

## Objective

This PR adds provision for configuring the scm context and oauth flow based on the github cloud account

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
