### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-scm-github",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Github implementation for the scm-base class",
   "main": "index.js",
   "scripts": {
@@ -47,9 +47,9 @@
     "@octokit/webhooks-methods": "^4.0.0",
     "circuit-fuses": "^5.0.0",
     "joi": "^17.7.0",
-    "screwdriver-data-schema": "^23.0.4",
+    "screwdriver-data-schema": "^24.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-scm-base": "^8.2.0",
+    "screwdriver-scm-base": "^9.0.0",
     "screwdriver-scm-github-graphql": "^1.1.0",
     "ssh-keygen": "^0.5.0"
   },


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config


## Context

Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
