### PR TITLE
[1] fix(3225): organize the return values of _parseHook

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1879,7 +1879,7 @@ jobs:
             });
         });
 
-        it('resolves null for a pull request payload from incorrect ghe enterprise cloud', () => {
+        it('rejects for a pull request payload from incorrect ghe enterprise cloud', () => {
             const scmGHEC = new GithubScm({
                 oauthClientId: 'abcdefg',
                 oauthClientSecret: 'defghijk',
@@ -1897,9 +1897,15 @@ jobs:
                 }
             });
 
-            return scmGHEC.parseHook(testHeaders, testPayloadPrBadSlug).then(result => {
-                assert.isNull(result);
-            });
+            return scmGHEC
+                .parseHook(testHeaders, testPayloadPrBadSlug)
+                .then(() => {
+                    assert.fail('This should not fail the tests');
+                })
+                .catch(err => {
+                    assert.include(err.message, 'Skipping incorrect scm context for hook parsing');
+                    assert.strictEqual(err.statusCode, 400);
+                });
         });
 
         it('parses a payload for a pull request event payload', () => {
@@ -1951,9 +1957,15 @@ jobs:
         it('rejects when ssh host is not valid', () => {
             testHeaders['x-hub-signature'] = 'sha1=1b51a3f9f548fdacab52c0e83f9a63f8cbb4b591';
 
-            return scm.parseHook(testHeaders, testPayloadPingBadSshHost).then(result => {
-                assert.isNull(result);
-            });
+            return scm
+                .parseHook(testHeaders, testPayloadPingBadSshHost)
+                .then(() => {
+                    assert.fail('This should not fail the tests');
+                })
+                .catch(err => {
+                    assert.include(err.message, 'Incorrect checkout SshHost');
+                    assert.strictEqual(err.statusCode, 400);
+                });
         });
 
         it('rejects when signature is not valid', () => {
@@ -1966,7 +1978,7 @@ jobs:
                 })
                 .catch(err => {
                     assert.equal(err.message, 'Invalid x-hub-signature');
-                    assert.strictEqual(err.statusCode, 500);
+                    assert.strictEqual(err.statusCode, 400);
                 });
         });
     });
@@ -3524,11 +3536,11 @@ jobs:
             });
         });
 
-        it('returns false when the github event is not valid', () => {
+        it('returns true when the github event is not valid', () => {
             testHeaders['x-github-event'] = 'REEEEEEEE';
 
             return scm.canHandleWebhook(testHeaders, testPayloadPush).then(result => {
-                assert.strictEqual(result, false);
+                assert.strictEqual(result, true);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the `_parseHook` method  returns Object or null or throw Error.
However, their return values are not properly conditioned.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Organize the return values by the following:

- return Object (parsed result): this `scm` is correct and Screwdriver do actions with this webhook (e.g. `push` event)
- return null: this `scm` is correct and Screwdriver do nothing (e.g. `delete` event)
- throw Error: this `scm` is not correct

Then we can handle whether the webhook is correct or not at [here](https://github.com/screwdriver-cd/screwdriver/blob/ef31fca55eaff2548f7486795de41e84f87a675d/plugins/webhooks/index.js#L68-L73).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3225

PR
- 

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
