### PR TITLE
feat: add prMerged flag to webhook result

### DIFF
--- a/index.js
+++ b/index.js
@@ -1557,6 +1557,7 @@ class GithubScm extends Scm {
                 const prTitle = hoek.reach(webhookPayload, 'pull_request.title');
                 const baseSource = hoek.reach(webhookPayload, 'pull_request.base.repo.id');
                 const headSource = hoek.reach(webhookPayload, 'pull_request.head.repo.id');
+                const prMerged = hoek.reach(webhookPayload, 'pull_request.merged');
                 const prSource = baseSource === headSource ? 'branch' : 'fork';
                 const ref = `pull/${prNum}/merge`;
 
@@ -1584,7 +1585,8 @@ class GithubScm extends Scm {
                     type: 'pr',
                     username: hoek.reach(webhookPayload, 'sender.login'),
                     hookId,
-                    scmContext
+                    scmContext,
+                    prMerged
                 };
             }
             case 'push': {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1741,7 +1741,8 @@ jobs:
                 type: 'pr',
                 username: 'baxterthehacker2',
                 hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
-                scmContext: 'github:github.com'
+                scmContext: 'github:github.com',
+                prMerged: false
             };
 
             testHeaders = {


### PR DESCRIPTION
## Context

SD configuration currently does not support pull_request closed trigger, to enable this feature we need to additional parsed information from webhook

## Objective

This PR adds `prMerged` flag to parsed webhook response

## References

https://github.com/screwdriver-cd/data-schema/pull/597

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
