### PR TITLE
fix: Improve error handling in the getPrInfo method of scm-github

### DIFF
--- a/index.js
+++ b/index.js
@@ -1782,9 +1782,9 @@ class GithubScm extends Scm {
             lookupConfig.scmRepo = config.scmRepo;
         }
 
-        const scmInfo = await this.lookupScmUri(lookupConfig);
-
         try {
+            const scmInfo = await this.lookupScmUri(lookupConfig);
+
             const pullRequestInfo = await this.breaker.runCommand({
                 action: 'get',
                 scopeType: 'pulls',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Related PR is below.
https://github.com/screwdriver-cd/screwdriver/pull/3353

This PR improves error handling in the `getPrInfo` method of `scm-github`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Errors thrown by lookupScmUri won’t be caught because the call is outside the try...catch block.
  - Therefore, we will modify the code to call lookupScmUri inside a try-catch block. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
