### PR TITLE
feat(3333): Add skip git clone variable [1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -908,16 +908,14 @@ class GithubScm extends Scm {
 
             // Fetch a pull request
             command.push(
-                ...[
-                    `echo 'Fetching PR ${prRef}'`,
-                    `$SD_GIT_WRAPPER "git fetch origin ${prRef}"`,
-                    `export PR_BASE_BRANCH_NAME='${singleQuoteEscapedBranch}'`,
-                    `export PR_BRANCH_NAME='${baseRepo}/${singleQuoteEscapedPrBranch}'`,
-                    `echo 'Checking out the PR branch ${singleQuoteEscapedPrBranch}'`,
-                    `$SD_GIT_WRAPPER "git checkout ${LOCAL_BRANCH_NAME}"`,
-                    `$SD_GIT_WRAPPER "git merge '${doubleQuoteEscapedBranch}'"`,
-                    `export GIT_BRANCH=origin/refs/${prRef}`
-                ]
+                `echo 'Fetching PR ${prRef}'`,
+                `$SD_GIT_WRAPPER "git fetch origin ${prRef}"`,
+                `export PR_BASE_BRANCH_NAME='${singleQuoteEscapedBranch}'`,
+                `export PR_BRANCH_NAME='${baseRepo}/${singleQuoteEscapedPrBranch}'`,
+                `echo 'Checking out the PR branch ${singleQuoteEscapedPrBranch}'`,
+                `$SD_GIT_WRAPPER "git checkout ${LOCAL_BRANCH_NAME}"`,
+                `$SD_GIT_WRAPPER "git merge '${doubleQuoteEscapedBranch}'"`,
+                `export GIT_BRANCH=origin/refs/${prRef}`
             );
         } else {
             command.push(`export GIT_BRANCH='origin/${singleQuoteEscapedBranch}'`);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Pre-refactoring to add git clone skip option to the checkout command during setup.
The actual addition of skip option will be carried out with the following content
- https://github.com/screwdriver-cd/scm-github/pull/248

Simple differences between https://github.com/screwdriver-cd/scm-github/pull/248 and the changes in this PR can be found in the following draft
- https://github.com/sonic-screwdriver-cd/scm-github/pull/2

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Refactoring without changing the results in any way to clarify shell indentation relationships and put the git commands together in a way that makes them easy to add skip option.

Note 
- There are some areas around sparse checkout where there is no space just before`else` or just before `then` in if, and to ensure that this modification does not change the behaviour, the description is written to be as tested.
  - These will be fixed with https://github.com/screwdriver-cd/scm-github/pull/248

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3333

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
