### PR TITLE
fix(3384): Failure to get user info from scm should not throw error

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "joi": "^17.13.3",
     "screwdriver-data-schema": "^25.0.0",
     "screwdriver-logger": "^3.0.0",
-    "screwdriver-scm-base": "^10.0.0",
+    "screwdriver-scm-base": "^10.0.1",
     "screwdriver-scm-github-graphql": "^2.0.0",
     "ssh-keygen": "^0.5.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2250,18 +2250,21 @@ jobs:
                     token: 'randomtoken',
                     username
                 })
-                .then(
-                    () => {
-                        assert.fail('This should not fail the test');
-                    },
-                    err => {
-                        assert.deepEqual(err, testError);
-
-                        assert.calledWith(githubMock.users.getByUsername, {
-                            username
-                        });
-                    }
-                );
+                .then(author => {
+                    assert.calledWith(githubMock.users.getByUsername, {
+                        username
+                    });
+                    assert.deepEqual(
+                        {
+                            id: '',
+                            avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
+                            name: username,
+                            username,
+                            url: 'https://cd.screwdriver.cd/'
+                        },
+                        author
+                    );
+                });
         });
     });
 


### PR DESCRIPTION
## Context

Changes made in the https://github.com/screwdriver-cd/scm-base/pull/101 has resulted in few test failures

## Objective

Adapt the tests to align with the latest changes

## References

https://github.com/screwdriver-cd/screwdriver/issues/3384

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
