### PR TITLE
fix(3415): Do not treat "internal" repo as "private"

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,7 +308,7 @@ class GithubScm extends Scm {
 
                 repoFullName = repo.data.full_name;
                 defaultBranch = repo.data.default_branch;
-                privateRepo = repo.data.private;
+                privateRepo = repo.data.private && repo.data.visibility === 'private';
             } catch (err) {
                 logger.error('Failed to lookupScmUri: ', err);
                 throw err;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2584,6 +2584,66 @@ jobs:
                 });
         });
 
+        it('decorates a scm uri associated with a private repo', () => {
+            const scmUri = 'github.com:102498:boat!"#$%&\'()-=|@`{;+]},<.>/　🚗';
+
+            githubMock.request.resolves({
+                data: {
+                    full_name: 'iAm/theCaptain',
+                    private: true,
+                    visibility: 'private'
+                }
+            });
+
+            return scm
+                .decorateUrl({
+                    scmUri,
+                    token: 'mytokenfortesting'
+                })
+                .then(data => {
+                    assert.deepEqual(data, {
+                        branch: 'boat!"#$%&\'()-=|@`{;+]},<.>/　🚗',
+                        name: 'iAm/theCaptain',
+                        url: `https://github.com/iAm/theCaptain/tree/${encodeURIComponent(
+                            'boat!"#$%&\'()-=|@`{;+]},<.>/　🚗'
+                        )}`,
+                        rootDir: '',
+                        private: true
+                    });
+                    assert.calledWith(githubMock.request, 'GET /repositories/:id', { id: '102498' });
+                });
+        });
+
+        it('decorates a scm uri associated with an internal repo', () => {
+            const scmUri = 'github.com:102498:boat!"#$%&\'()-=|@`{;+]},<.>/　🚗';
+
+            githubMock.request.resolves({
+                data: {
+                    full_name: 'iAm/theCaptain',
+                    private: true,
+                    visibility: 'internal'
+                }
+            });
+
+            return scm
+                .decorateUrl({
+                    scmUri,
+                    token: 'mytokenfortesting'
+                })
+                .then(data => {
+                    assert.deepEqual(data, {
+                        branch: 'boat!"#$%&\'()-=|@`{;+]},<.>/　🚗',
+                        name: 'iAm/theCaptain',
+                        url: `https://github.com/iAm/theCaptain/tree/${encodeURIComponent(
+                            'boat!"#$%&\'()-=|@`{;+]},<.>/　🚗'
+                        )}`,
+                        rootDir: '',
+                        private: false
+                    });
+                    assert.calledWith(githubMock.request, 'GET /repositories/:id', { id: '102498' });
+                });
+        });
+
         it('decorates a scm uri with rootDir', () => {
             const scmUri = 'github.com:102498:boat!"#$%&\'()-=|@`{;+]},<.>/　🚗:src/app/component';
 


### PR DESCRIPTION
## Context

Internal repositories are being marked and treated as private repositories.

The current logic in GitHub SCM module only relies on `private` property from the GitHub API response to identify whether a repository is private or not.
But, this property alone is not sufficient. Both private and internal repositories will have `private: true`.

## Objective

In addition to `private` property, we also need to check the value of `visibility` property.

| Repository Type | API Property: `private` (Boolean) | API Property: `visibility` (String) | Description |
| :--- | :---: | :---: | :--- |
| **Public** | `false` | `public` | Accessible to everyone on the internet. |
| **Private** | `true` | `private` | Only accessible to the owner and explicitly shared collaborators/teams. |
| **Internal** | `true` | `internal` | Accessible to all members of the organization/enterprise, but hidden from outsiders. |

Mark the repo as private when all the below criteria are met
- "private": true
- "visibility": "private"

## References
https://github.com/screwdriver-cd/screwdriver/issues/3415

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
