### PR TITLE
Fix: Split large PR file processing to avoid circuit breaker timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,12 +243,32 @@ class GithubScm extends Scm {
         }
 
         // eslint-disable-next-line no-underscore-dangle
-        this.breaker = new Breaker(this._githubCommand.bind(this), {
-            // Do not retry when there is a 4XX error
+        this.breaker = this._createBreakerWithTimeout();
+
+        this.scmGithubGQL = config.gheCloud
+            ? new ScmGithubGraphQL({
+                  graphqlUrl: this.config.githubGraphQLUrl
+              })
+            : null;
+    }
+
+    /**
+     * Create a breaker instance with custom timeout
+     * @method _createBreakerWithTimeout
+     * @param  {Number}  [timeoutMultiplier=1]  Multiplier for the base timeout
+     * @return {Breaker}                        A new Breaker instance with adjusted timeout
+     * @private
+     */
+    _createBreakerWithTimeout(timeoutMultiplier = 1) {
+        const breakerConfig = (this.config.fusebox && this.config.fusebox.breaker) || {};
+        const baseTimeout = breakerConfig.timeout || 10000;
+
+        return new Breaker(this._githubCommand.bind(this), {
             shouldRetry: err => err && err.statusCode && !(err.statusCode >= 400 && err.statusCode < 500),
             retry: this.config.fusebox.retry,
             breaker: {
-                ...this.config.fusebox.breaker,
+                ...breakerConfig,
+                timeout: baseTimeout * timeoutMultiplier,
                 errorFn(err) {
                     if (err.statusCode) {
                         return !(err.statusCode >= 400 && err.statusCode < 500);
@@ -258,12 +278,6 @@ class GithubScm extends Scm {
                 }
             }
         });
-
-        this.scmGithubGQL = config.gheCloud
-            ? new ScmGithubGraphQL({
-                  graphqlUrl: this.config.githubGraphQLUrl
-              })
-            : null;
     }
 
     /**
@@ -1564,35 +1578,13 @@ class GithubScm extends Scm {
                 });
 
                 const fileCount = prInfo.data.changed_files;
-                const timeoutMultiplier = Math.ceil(fileCount / PR_FILES_PAGE_SIZE);
 
-                // Determine timeout value
-                const timeout =
-                    (this.config.fusebox && this.config.fusebox.breaker && this.config.fusebox.breaker.timeout) ||
-                    10000;
-
-                // Create a new breaker with adjusted timeout if needed
                 let getFilesBreaker = this.breaker;
 
-                if (timeoutMultiplier > 1) {
-                    // Get the existing breaker configuration
-                    const breakerConfig = this.config.fusebox.breaker || {};
+                if (fileCount > PR_FILES_PAGE_SIZE) {
+                    const timeoutMultiplier = Math.ceil(fileCount / PR_FILES_PAGE_SIZE);
 
-                    getFilesBreaker = new Breaker(this._githubCommand.bind(this), {
-                        shouldRetry: err => err && err.statusCode && !(err.statusCode >= 400 && err.statusCode < 500),
-                        retry: this.config.fusebox.retry,
-                        breaker: {
-                            ...breakerConfig,
-                            timeout: timeout * timeoutMultiplier,
-                            errorFn(err) {
-                                if (err.statusCode) {
-                                    return !(err.statusCode >= 400 && err.statusCode < 500);
-                                }
-
-                                return true;
-                            }
-                        }
-                    });
+                    getFilesBreaker = this._createBreakerWithTimeout(timeoutMultiplier);
                 }
 
                 const files = await getFilesBreaker.runCommand({

--- a/index.js
+++ b/index.js
@@ -1567,7 +1567,7 @@ class GithubScm extends Scm {
                 const timeoutMultiplier = Math.ceil(fileCount / PR_FILES_PAGE_SIZE);
 
                 // Store original breaker config
-                const originalBreakerConfig = this.breaker.config;
+                const originalBreakerConfig = this.config.fusebox;
 
                 // Update breaker timeout for large PR file lists
                 this.breaker.config = {
@@ -1588,7 +1588,7 @@ class GithubScm extends Scm {
                 });
 
                 // Restore original breaker config
-                this.breaker.config = originalBreakerConfig;
+                this.config.fusebox = originalBreakerConfig;
 
                 return files.map(file => file.filename);
             } catch (err) {

--- a/index.js
+++ b/index.js
@@ -1553,21 +1553,31 @@ class GithubScm extends Scm {
                 if (scmRepo) {
                     lookupConfig.scmRepo = scmRepo;
                 }
-
+                
                 const scmInfo = await this.lookupScmUri(lookupConfig);
-                const files = await this.breaker.runCommand({
-                    scopeType: 'paginate',
-                    route: 'GET /repos/:owner/:repo/pulls/:pull_number/files',
+
+                // Getting PR Info to check number of changed files
+                const prInfo = await this.breaker.runCommand({
+                    action: 'get',
+                    scopeType: 'pulls',
                     token,
-                    params: {
-                        owner: scmInfo.owner,
-                        repo: scmInfo.repo,
-                        pull_number: prNum,
-                        per_page: PR_FILES_PAGE_SIZE
-                    }
+                    params: { owner: scmInfo.owner, repo: scmInfo.repo, pull_number: prNum }
                 });
 
-                return files.map(file => file.filename);
+                const fileCount = prInfo.data.changed_files;
+                const allFiles = [];
+                for (let page = 1; page <= Math.ceil(fileCount / PR_FILES_PAGE_SIZE); page++) {
+                    const pageFiles = await this.breaker.runCommand({
+                        action: 'listFiles',
+                        scopeType: 'pulls',
+                        token,
+                        params: { owner: scmInfo.owner, repo: scmInfo.repo, pull_number: prNum, per_page: PR_FILES_PAGE_SIZE, page }
+                    });
+                    allFiles.push(...pageFiles.data);
+                    if (pageFiles.data.length < PR_FILES_PAGE_SIZE) break;
+                }
+
+                return allFiles.map(file => file.filename);
             } catch (err) {
                 logger.error('Failed to getChangedFiles: ', err);
 

--- a/index.js
+++ b/index.js
@@ -1566,16 +1566,36 @@ class GithubScm extends Scm {
                 const fileCount = prInfo.data.changed_files;
                 const timeoutMultiplier = Math.ceil(fileCount / PR_FILES_PAGE_SIZE);
 
-                // Store original breaker config
-                const originalBreakerConfig = this.config.fusebox;
+                // Determine timeout value
+                const timeout =
+                    (this.config.fusebox && this.config.fusebox.breaker && this.config.fusebox.breaker.timeout) ||
+                    10000;
 
-                // Update breaker timeout for large PR file lists
-                this.breaker.config = {
-                    ...originalBreakerConfig,
-                    timeout: (originalBreakerConfig.timeout || 10000) * timeoutMultiplier
-                };
+                // Create a new breaker with adjusted timeout if needed
+                let getFilesBreaker = this.breaker;
 
-                const files = await this.breaker.runCommand({
+                if (timeoutMultiplier > 1) {
+                    // Get the existing breaker configuration
+                    const breakerConfig = this.config.fusebox.breaker || {};
+
+                    getFilesBreaker = new Breaker(this._githubCommand.bind(this), {
+                        shouldRetry: err => err && err.statusCode && !(err.statusCode >= 400 && err.statusCode < 500),
+                        retry: this.config.fusebox.retry,
+                        breaker: {
+                            ...breakerConfig,
+                            timeout: timeout * timeoutMultiplier,
+                            errorFn(err) {
+                                if (err.statusCode) {
+                                    return !(err.statusCode >= 400 && err.statusCode < 500);
+                                }
+
+                                return true;
+                            }
+                        }
+                    });
+                }
+
+                const files = await getFilesBreaker.runCommand({
                     scopeType: 'paginate',
                     route: 'GET /repos/:owner/:repo/pulls/:pull_number/files',
                     token,
@@ -1586,9 +1606,6 @@ class GithubScm extends Scm {
                         per_page: PR_FILES_PAGE_SIZE
                     }
                 });
-
-                // Restore original breaker config
-                this.config.fusebox = originalBreakerConfig;
 
                 return files.map(file => file.filename);
             } catch (err) {

--- a/index.js
+++ b/index.js
@@ -1553,7 +1553,6 @@ class GithubScm extends Scm {
                 if (scmRepo) {
                     lookupConfig.scmRepo = scmRepo;
                 }
-                
                 const scmInfo = await this.lookupScmUri(lookupConfig);
 
                 // Getting PR Info to check number of changed files
@@ -1565,19 +1564,33 @@ class GithubScm extends Scm {
                 });
 
                 const fileCount = prInfo.data.changed_files;
-                const allFiles = [];
-                for (let page = 1; page <= Math.ceil(fileCount / PR_FILES_PAGE_SIZE); page++) {
-                    const pageFiles = await this.breaker.runCommand({
-                        action: 'listFiles',
-                        scopeType: 'pulls',
-                        token,
-                        params: { owner: scmInfo.owner, repo: scmInfo.repo, pull_number: prNum, per_page: PR_FILES_PAGE_SIZE, page }
-                    });
-                    allFiles.push(...pageFiles.data);
-                    if (pageFiles.data.length < PR_FILES_PAGE_SIZE) break;
-                }
+                const timeoutMultiplier = Math.ceil(fileCount / PR_FILES_PAGE_SIZE);
 
-                return allFiles.map(file => file.filename);
+                // Store original breaker config
+                const originalBreakerConfig = this.breaker.config;
+
+                // Update breaker timeout for large PR file lists
+                this.breaker.config = {
+                    ...originalBreakerConfig,
+                    timeout: (originalBreakerConfig.timeout || 10000) * timeoutMultiplier
+                };
+
+                const files = await this.breaker.runCommand({
+                    scopeType: 'paginate',
+                    route: 'GET /repos/:owner/:repo/pulls/:pull_number/files',
+                    token,
+                    params: {
+                        owner: scmInfo.owner,
+                        repo: scmInfo.repo,
+                        pull_number: prNum,
+                        per_page: PR_FILES_PAGE_SIZE
+                    }
+                });
+
+                // Restore original breaker config
+                this.breaker.config = originalBreakerConfig;
+
+                return files.map(file => file.filename);
             } catch (err) {
                 logger.error('Failed to getChangedFiles: ', err);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1573,6 +1573,42 @@ jobs:
                     assert.deepEqual(result, []);
                 });
         });
+
+        it('increases breaker timeout for PRs with more than 100 files', () => {
+            // Mock PR info with 250 files (3 pages, timeout should be 3x)
+            const prInfoWith250Files = {
+                data: {
+                    ...testPrGet,
+                    changed_files: 250
+                }
+            };
+
+            const files = Array.from({ length: 250 }, (_, i) => ({
+                filename: `file${i + 1}.js`,
+                status: 'modified'
+            }));
+
+            githubMock.request.resolves({ data: { full_name: 'iAm/theCaptain' } });
+            githubMock.pulls.get
+                .onFirstCall()
+                .resolves({ data: testPrGetNullMergeable })
+                .onSecondCall()
+                .resolves(prInfoWith250Files);
+
+            githubMock.paginate.resolves(files);
+
+            return scm
+                .getChangedFiles({
+                    type: 'pr',
+                    token,
+                    webhookConfig: null,
+                    scmUri: 'github.com:28476:master',
+                    prNum: 1
+                })
+                .then(result => {
+                    assert.equal(result.length, 250);
+                });
+        });
     });
 
     describe('waitPrMergeability', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines-per-function */
+
 'use strict';
 
 const { assert, AssertionError } = require('chai');
@@ -1589,10 +1591,13 @@ jobs:
             }));
 
             githubMock.request.resolves({ data: { full_name: 'iAm/theCaptain' } });
+            // Mock pulls.get to handle multiple calls
             githubMock.pulls.get
                 .onFirstCall()
                 .resolves({ data: testPrGetNullMergeable })
                 .onSecondCall()
+                .resolves({ data: testPrGet })
+                .onCall(2)
                 .resolves(prInfoWith250Files);
 
             githubMock.paginate.resolves(files);
@@ -1607,6 +1612,7 @@ jobs:
                 })
                 .then(result => {
                     assert.equal(result.length, 250);
+                    assert.equal(githubMock.paginate.callCount, 1);
                 });
         });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1580,7 +1580,7 @@ jobs:
             // Mock PR info with 250 files (3 pages, timeout should be 3x)
             const prInfoWith250Files = {
                 data: {
-                    ...testPrGet,
+                    ...testPrGet.data,
                     changed_files: 250
                 }
             };


### PR DESCRIPTION
## Context

PRs with large number of changed files timeout.

## Objective

split the file retrieval process for large Pull Requests (PRs) to prevent request timeouts.

## References


## License


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
