### PR TITLE
feat: Add request-local caching for repeated SCM lookups [1]

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const PR_COMMENTS_REGEX = /^.+pipelines\/(\d+)\/builds.+ ([\w-:]+)$/;
 const PR_COMMENTS_KEYWORD_REGEX = /^__(.*)__.*$/;
 const Scm = require('screwdriver-scm-base');
 const logger = require('screwdriver-logger');
+const { cacheBy, getRequestCacheStorage } = require('./requestCache');
 const DEFAULT_AUTHOR = {
     avatar: 'https://cd.screwdriver.cd/assets/unknown_user.png',
     name: 'n/a',
@@ -131,6 +132,14 @@ function getInfo(scmUrl, rootDir) {
 }
 
 class GithubScm extends Scm {
+    withRequestCache(requestCache, method) {
+        if (!(requestCache instanceof Map)) {
+            return method();
+        }
+
+        return getRequestCacheStorage().run(requestCache, method);
+    }
+
     /**
      * Github command to run
      * @method _githubCommand
@@ -290,55 +299,67 @@ class GithubScm extends Scm {
      * @return {Promise}                        Resolves to an object containing repository-related information
      */
     async lookupScmUri({ scmUri, scmRepo, token }) {
-        const parts = scmUri.split(':');
-        const [scmHost, scmId, scmBranch, ...rootDirParts] = parts;
-        const rootDir = rootDirParts.join(':');
+        return cacheBy({
+            scope: 'lookupScmUri',
+            params: {
+                scmUri,
+                scmRepoName: scmRepo ? scmRepo.name : null,
+                scmRepoBranch: scmRepo ? scmRepo.branch : null,
+                scmRepoPrivateRepo: scmRepo ? scmRepo.privateRepo || false : null,
+                token: scmRepo ? null : token
+            },
+            fetcher: async () => {
+                const parts = scmUri.split(':');
+                const [scmHost, scmId, scmBranch, ...rootDirParts] = parts;
+                const rootDir = rootDirParts.join(':');
 
-        let repoFullName;
-        let defaultBranch;
-        let privateRepo;
+                let repoFullName;
+                let defaultBranch;
+                let privateRepo;
 
-        if (scmRepo) {
-            repoFullName = scmRepo.name;
-            privateRepo = scmRepo.privateRepo || false;
-            defaultBranch = scmRepo.branch;
-        } else {
-            try {
-                const myHost = this.config.gheHost || 'github.com';
+                if (scmRepo) {
+                    repoFullName = scmRepo.name;
+                    privateRepo = scmRepo.privateRepo || false;
+                    defaultBranch = scmRepo.branch;
+                } else {
+                    try {
+                        const myHost = this.config.gheHost || 'github.com';
 
-                if (scmHost !== myHost) {
-                    throwError(
-                        `Pipeline's scmHost ${scmHost} does not match with user's scmHost ${this.config.gheHost}`,
-                        403
-                    );
+                        if (scmHost !== myHost) {
+                            throwError(
+                                `Pipeline's scmHost ${scmHost} does not match with user's scmHost ${this.config.gheHost}`,
+                                403
+                            );
+                        }
+                        // https://github.com/octokit/rest.js/issues/163
+                        const repo = await this.breaker.runCommand({
+                            scopeType: 'request',
+                            route: 'GET /repositories/:id',
+                            token,
+                            params: { id: scmId }
+                        });
+
+                        repoFullName = repo.data.full_name;
+                        defaultBranch = repo.data.default_branch;
+                        privateRepo = repo.data.private && repo.data.visibility === 'private';
+                    } catch (err) {
+                        logger.error('Failed to lookupScmUri: ', err);
+                        throw err;
+                    }
                 }
-                // https://github.com/octokit/rest.js/issues/163
-                const repo = await this.breaker.runCommand({
-                    scopeType: 'request',
-                    route: 'GET /repositories/:id',
-                    token,
-                    params: { id: scmId }
-                });
 
-                repoFullName = repo.data.full_name;
-                defaultBranch = repo.data.default_branch;
-                privateRepo = repo.data.private && repo.data.visibility === 'private';
-            } catch (err) {
-                logger.error('Failed to lookupScmUri: ', err);
-                throw err;
+                const [repoOwner, repoName] = repoFullName.split('/');
+
+                return {
+                    branch: scmBranch || defaultBranch,
+                    host: scmHost,
+                    repo: repoName,
+                    owner: repoOwner,
+                    rootDir: rootDir || '',
+                    privateRepo
+                };
             }
-        }
-
-        const [repoOwner, repoName] = repoFullName.split('/');
-
-        return {
-            branch: scmBranch || defaultBranch,
-            host: scmHost,
-            repo: repoName,
-            owner: repoOwner,
-            rootDir: rootDir || '',
-            privateRepo
-        };
+        });
     }
 
     /**
@@ -1001,43 +1022,53 @@ class GithubScm extends Scm {
      * @return {Promise}                        Resolves to an array of objects storing opened PR names and refs
      */
     async _getOpenedPRs({ scmUri, token, scmRepo }) {
-        const lookupConfig = {
-            scmUri,
-            token
-        };
+        return cacheBy({
+            scope: 'getOpenedPRs',
+            params: {
+                scmUri,
+                scmRepoName: scmRepo ? scmRepo.name : null,
+                token
+            },
+            fetcher: async () => {
+                const lookupConfig = {
+                    scmUri,
+                    token
+                };
 
-        if (scmRepo) {
-            lookupConfig.scmRepo = scmRepo;
-        }
-
-        const { owner, repo } = await this.lookupScmUri(lookupConfig);
-
-        try {
-            const pullRequests = await this.breaker.runCommand({
-                action: 'list',
-                scopeType: 'pulls',
-                token,
-                params: {
-                    owner,
-                    repo,
-                    state: 'open',
-                    per_page: 100
+                if (scmRepo) {
+                    lookupConfig.scmRepo = scmRepo;
                 }
-            });
 
-            return pullRequests.data.map(pullRequest => ({
-                name: `PR-${pullRequest.number}`,
-                ref: `pull/${pullRequest.number}/merge`,
-                username: pullRequest.user.login,
-                title: pullRequest.title,
-                createTime: pullRequest.created_at,
-                url: pullRequest.html_url,
-                userProfile: pullRequest.user.html_url
-            }));
-        } catch (err) {
-            logger.error('Failed to getOpenedPRs: ', err);
-            throw err;
-        }
+                const { owner, repo } = await this.lookupScmUri(lookupConfig);
+
+                try {
+                    const pullRequests = await this.breaker.runCommand({
+                        action: 'list',
+                        scopeType: 'pulls',
+                        token,
+                        params: {
+                            owner,
+                            repo,
+                            state: 'open',
+                            per_page: 100
+                        }
+                    });
+
+                    return pullRequests.data.map(pullRequest => ({
+                        name: `PR-${pullRequest.number}`,
+                        ref: `pull/${pullRequest.number}/merge`,
+                        username: pullRequest.user.login,
+                        title: pullRequest.title,
+                        createTime: pullRequest.created_at,
+                        url: pullRequest.html_url,
+                        userProfile: pullRequest.user.html_url
+                    }));
+                } catch (err) {
+                    logger.error('Failed to getOpenedPRs: ', err);
+                    throw err;
+                }
+            }
+        });
     }
 
     /**
@@ -1304,57 +1335,70 @@ class GithubScm extends Scm {
      * @return {Promise}                      Resolves to string containing contents of file
      */
     async _getFile({ scmUri, path, token, ref, scmRepo }) {
-        let fullPath = path;
-        let owner;
-        let repo;
-        let branch;
-        let rootDir;
-
-        // If full path to a file is provided, e.g. git@github.com:screwdriver-cd/scm-github.git:path/to/a/file.yaml
-        if (CHECKOUT_URL_REGEX.test(path)) {
-            ({ owner, repo, branch, rootDir } = getInfo(fullPath));
-            fullPath = rootDir;
-        } else {
-            const lookupConfig = {
+        return cacheBy({
+            scope: 'getFile',
+            params: {
                 scmUri,
-                token
-            };
-
-            if (scmRepo) {
-                lookupConfig.scmRepo = scmRepo;
-            }
-
-            ({ owner, repo, branch, rootDir } = await this.lookupScmUri(lookupConfig));
-            fullPath = rootDir ? Path.join(rootDir, path) : path;
-        }
-
-        try {
-            const file = await this.breaker.runCommand({
-                action: 'getContent',
+                path,
+                ref: ref || null,
+                scmRepoName: scmRepo ? scmRepo.name : null,
                 token,
-                params: {
-                    owner,
-                    repo,
-                    path: fullPath,
-                    ref: ref || branch || DEFAULT_BRANCH
+                isCheckoutPath: CHECKOUT_URL_REGEX.test(path)
+            },
+            fetcher: async () => {
+                let fullPath = path;
+                let owner;
+                let repo;
+                let branch;
+                let rootDir;
+
+                // If full path to a file is provided, e.g. git@github.com:screwdriver-cd/scm-github.git:path/to/a/file.yaml
+                if (CHECKOUT_URL_REGEX.test(path)) {
+                    ({ owner, repo, branch, rootDir } = getInfo(fullPath));
+                    fullPath = rootDir;
+                } else {
+                    const lookupConfig = {
+                        scmUri,
+                        token
+                    };
+
+                    if (scmRepo) {
+                        lookupConfig.scmRepo = scmRepo;
+                    }
+
+                    ({ owner, repo, branch, rootDir } = await this.lookupScmUri(lookupConfig));
+                    fullPath = rootDir ? Path.join(rootDir, path) : path;
                 }
-            });
 
-            if (file.data.type !== 'file') {
-                throwError(`Path (${fullPath}) does not point to file`);
+                try {
+                    const file = await this.breaker.runCommand({
+                        action: 'getContent',
+                        token,
+                        params: {
+                            owner,
+                            repo,
+                            path: fullPath,
+                            ref: ref || branch || DEFAULT_BRANCH
+                        }
+                    });
+
+                    if (file.data.type !== 'file') {
+                        throwError(`Path (${fullPath}) does not point to file`);
+                    }
+
+                    return Buffer.from(file.data.content, file.data.encoding).toString();
+                } catch (err) {
+                    logger.error('Failed to getFile: ', err);
+
+                    if (err.statusCode === 404) {
+                        // Returns an empty file if there is no screwdriver.yaml
+                        return '';
+                    }
+
+                    throw err;
+                }
             }
-
-            return Buffer.from(file.data.content, file.data.encoding).toString();
-        } catch (err) {
-            logger.error('Failed to getFile: ', err);
-
-            if (err.statusCode === 404) {
-                // Returns an empty file if there is no screwdriver.yaml
-                return '';
-            }
-
-            throw err;
-        }
+        });
     }
 
     /**
@@ -1381,22 +1425,31 @@ class GithubScm extends Scm {
      * @return {Promise}                        Resolves an object with repo id and default branch
      */
     async _getRepoInfo(scmInfo, token, checkoutUrl) {
-        try {
-            const repo = await this.breaker.runCommand({
-                action: 'get',
-                token,
-                params: scmInfo
-            });
+        return cacheBy({
+            scope: 'getRepoInfo',
+            params: {
+                scmInfo,
+                token
+            },
+            fetcher: async () => {
+                try {
+                    const repo = await this.breaker.runCommand({
+                        action: 'get',
+                        token,
+                        params: scmInfo
+                    });
 
-            return { repoId: repo.data.id, defaultBranch: repo.data.default_branch };
-        } catch (err) {
-            if (err.statusCode === 404) {
-                throwError(`Cannot find repository ${checkoutUrl}`, 404);
+                    return { repoId: repo.data.id, defaultBranch: repo.data.default_branch };
+                } catch (err) {
+                    if (err.statusCode === 404) {
+                        throwError(`Cannot find repository ${checkoutUrl}`, 404);
+                    }
+
+                    logger.error('Failed to getRepoId: ', err);
+                    throw err;
+                }
             }
-
-            logger.error('Failed to getRepoId: ', err);
-            throw err;
-        }
+        });
     }
 
     /**
@@ -1408,26 +1461,35 @@ class GithubScm extends Scm {
      * @return {Promise}                       Resolves to decorated user object
      */
     async _decorateAuthor(config) {
-        try {
-            const user = await this.breaker.runCommand({
-                action: 'getByUsername',
-                scopeType: 'users',
-                token: config.token,
-                params: { username: config.username }
-            });
-            const name = user.data.name || user.data.login;
+        return cacheBy({
+            scope: 'decorateAuthor',
+            params: {
+                username: config.username,
+                token: config.token
+            },
+            fetcher: async () => {
+                try {
+                    const user = await this.breaker.runCommand({
+                        action: 'getByUsername',
+                        scopeType: 'users',
+                        token: config.token,
+                        params: { username: config.username }
+                    });
+                    const name = user.data.name || user.data.login;
 
-            return {
-                id: user.data.id.toString(),
-                avatar: user.data.avatar_url,
-                name,
-                username: user.data.login,
-                url: user.data.html_url
-            };
-        } catch (err) {
-            logger.error('Failed to decorateAuthor: ', err);
-            throw err;
-        }
+                    return {
+                        id: user.data.id.toString(),
+                        avatar: user.data.avatar_url,
+                        name,
+                        username: user.data.login,
+                        url: user.data.html_url
+                    };
+                } catch (err) {
+                    logger.error('Failed to decorateAuthor: ', err);
+                    throw err;
+                }
+            }
+        });
     }
 
     /**
@@ -1441,67 +1503,78 @@ class GithubScm extends Scm {
      * @return {Promise}                         Resolves to decorated commit object
      */
     async _decorateCommit(config) {
-        const lookupConfig = {
-            scmUri: config.scmUri,
-            token: config.token
-        };
+        return cacheBy({
+            scope: 'decorateCommit',
+            params: {
+                scmUri: config.scmUri,
+                sha: config.sha,
+                scmRepoName: config.scmRepo ? config.scmRepo.name : null,
+                token: config.token
+            },
+            fetcher: async () => {
+                const lookupConfig = {
+                    scmUri: config.scmUri,
+                    token: config.token
+                };
 
-        if (config.scmRepo) {
-            lookupConfig.scmRepo = config.scmRepo;
-        }
-
-        const scmInfo = await this.lookupScmUri(lookupConfig);
-
-        try {
-            const commit = await this.breaker.runCommand({
-                action: 'getCommit',
-                token: config.token,
-                params: {
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo,
-                    ref: config.sha
+                if (config.scmRepo) {
+                    lookupConfig.scmRepo = config.scmRepo;
                 }
-            });
 
-            const authorLogin = hoek.reach(commit, 'data.author.login');
-            const authorName = hoek.reach(commit, 'data.commit.author.name');
-            const committerLogin = hoek.reach(commit, 'data.committer.login');
-            const committerName = hoek.reach(commit, 'data.commit.committer.name');
-            let author = { ...DEFAULT_AUTHOR };
-            let committer = { ...DEFAULT_AUTHOR };
+                const scmInfo = await this.lookupScmUri(lookupConfig);
 
-            if (authorLogin) {
-                author = await this.decorateAuthor({
-                    token: config.token,
-                    username: authorLogin
-                });
-            } else if (authorName) {
-                author.name = authorName;
-            }
-
-            if (committerLogin) {
-                if (committerLogin === authorLogin) {
-                    committer = author;
-                } else {
-                    committer = await this.decorateAuthor({
+                try {
+                    const commit = await this.breaker.runCommand({
+                        action: 'getCommit',
                         token: config.token,
-                        username: committerLogin
+                        params: {
+                            owner: scmInfo.owner,
+                            repo: scmInfo.repo,
+                            ref: config.sha
+                        }
                     });
-                }
-            } else if (committerName) {
-                committer.name = committerName;
-            }
 
-            return {
-                author,
-                committer,
-                message: commit.data.commit.message,
-                url: commit.data.html_url
-            };
-        } catch (err) {
-            logger.error('Failed to decorateCommit: ', err);
-            throw err;
-        }
+                    const authorLogin = hoek.reach(commit, 'data.author.login');
+                    const authorName = hoek.reach(commit, 'data.commit.author.name');
+                    const committerLogin = hoek.reach(commit, 'data.committer.login');
+                    const committerName = hoek.reach(commit, 'data.commit.committer.name');
+                    let author = { ...DEFAULT_AUTHOR };
+                    let committer = { ...DEFAULT_AUTHOR };
+
+                    if (authorLogin) {
+                        author = await this.decorateAuthor({
+                            token: config.token,
+                            username: authorLogin
+                        });
+                    } else if (authorName) {
+                        author.name = authorName;
+                    }
+
+                    if (committerLogin) {
+                        if (committerLogin === authorLogin) {
+                            committer = author;
+                        } else {
+                            committer = await this.decorateAuthor({
+                                token: config.token,
+                                username: committerLogin
+                            });
+                        }
+                    } else if (committerName) {
+                        committer.name = committerName;
+                    }
+
+                    return {
+                        author,
+                        committer,
+                        message: commit.data.commit.message,
+                        url: commit.data.html_url
+                    };
+                } catch (err) {
+                    logger.error('Failed to decorateCommit: ', err);
+                    throw err;
+                }
+            }
+        });
     }
 
     /**
@@ -1867,56 +1940,70 @@ class GithubScm extends Scm {
      * @return {Promise}
      */
     async _getPrInfo(config) {
-        const lookupConfig = {
-            scmUri: config.scmUri,
-            token: config.token
-        };
+        const fetchPrInfo = async () => {
+            const lookupConfig = {
+                scmUri: config.scmUri,
+                token: config.token
+            };
 
-        if (config.scmRepo) {
-            lookupConfig.scmRepo = config.scmRepo;
-        }
-
-        try {
-            const scmInfo = await this.lookupScmUri(lookupConfig);
-
-            const pullRequestInfo = await this.breaker.runCommand({
-                action: 'get',
-                scopeType: 'pulls',
-                token: config.token,
-                params: {
-                    pull_number: config.prNum,
-                    owner: scmInfo.owner,
-                    repo: scmInfo.repo
-                }
-            });
-            let prSource = 'fork';
-
-            if (
-                pullRequestInfo.data.head.repo &&
-                pullRequestInfo.data.base.repo &&
-                pullRequestInfo.data.head.repo.id === pullRequestInfo.data.base.repo.id
-            ) {
-                prSource = 'branch';
+            if (config.scmRepo) {
+                lookupConfig.scmRepo = config.scmRepo;
             }
 
-            return {
-                name: `PR-${pullRequestInfo.data.number}`,
-                ref: `pull/${pullRequestInfo.data.number}/merge`,
-                sha: pullRequestInfo.data.head.sha,
-                prBranchName: pullRequestInfo.data.head.ref,
-                url: pullRequestInfo.data.html_url,
-                username: pullRequestInfo.data.user.login,
-                title: pullRequestInfo.data.title,
-                createTime: pullRequestInfo.data.created_at,
-                userProfile: pullRequestInfo.data.user.html_url,
-                baseBranch: pullRequestInfo.data.base.ref,
-                mergeable: pullRequestInfo.data.mergeable,
-                prSource
-            };
-        } catch (err) {
-            logger.error('Failed to getPrInfo: ', err);
-            throw err;
-        }
+            try {
+                const scmInfo = await this.lookupScmUri(lookupConfig);
+
+                const pullRequestInfo = await this.breaker.runCommand({
+                    action: 'get',
+                    scopeType: 'pulls',
+                    token: config.token,
+                    params: {
+                        pull_number: config.prNum,
+                        owner: scmInfo.owner,
+                        repo: scmInfo.repo
+                    }
+                });
+                let prSource = 'fork';
+
+                if (
+                    pullRequestInfo.data.head.repo &&
+                    pullRequestInfo.data.base.repo &&
+                    pullRequestInfo.data.head.repo.id === pullRequestInfo.data.base.repo.id
+                ) {
+                    prSource = 'branch';
+                }
+
+                return {
+                    name: `PR-${pullRequestInfo.data.number}`,
+                    ref: `pull/${pullRequestInfo.data.number}/merge`,
+                    sha: pullRequestInfo.data.head.sha,
+                    prBranchName: pullRequestInfo.data.head.ref,
+                    url: pullRequestInfo.data.html_url,
+                    username: pullRequestInfo.data.user.login,
+                    title: pullRequestInfo.data.title,
+                    createTime: pullRequestInfo.data.created_at,
+                    userProfile: pullRequestInfo.data.user.html_url,
+                    baseBranch: pullRequestInfo.data.base.ref,
+                    mergeable: pullRequestInfo.data.mergeable,
+                    prSource
+                };
+            } catch (err) {
+                logger.error('Failed to getPrInfo: ', err);
+                throw err;
+            }
+        };
+
+        return cacheBy({
+            scope: 'getPrInfo',
+            params: {
+                scmUri: config.scmUri,
+                prNum: config.prNum,
+                scmRepoName: config.scmRepo ? config.scmRepo.name : null,
+                token: config.token
+            },
+            fetcher: fetchPrInfo,
+            shouldCache: result => result.mergeable !== null && result.mergeable !== undefined
+        });
     }
 
     /**

--- a/requestCache.js
+++ b/requestCache.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { createHash } = require('crypto');
 const { AsyncLocalStorage } = require('async_hooks');
 
 const REQUEST_CACHE_STORAGE_KEY = Symbol.for('sd.requestCacheStorage');
@@ -20,10 +21,10 @@ function getRequestCacheStorage() {
  * Build a cache key for the given scope and params.
  * @param {String} scope Cache scope name
  * @param {Object} params Parameters contributing to the cache key
- * @returns {String} Serialized cache key
+ * @returns {String} Hashed cache key
  */
 function getRequestCacheKey(scope, params) {
-    return `${scope}:${JSON.stringify(params)}`;
+    return createHash('sha256').update(JSON.stringify({ scope, params })).digest('hex');
 }
 
 /**

--- a/requestCache.js
+++ b/requestCache.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const { AsyncLocalStorage } = require('async_hooks');
+
+const REQUEST_CACHE_STORAGE_KEY = Symbol.for('sd.requestCacheStorage');
+
+/**
+ * Get the request-local cache storage instance.
+ * @returns {AsyncLocalStorage<Map<string, Promise<*>>>} Async local storage for request cache entries
+ */
+function getRequestCacheStorage() {
+    if (!global[REQUEST_CACHE_STORAGE_KEY]) {
+        global[REQUEST_CACHE_STORAGE_KEY] = new AsyncLocalStorage();
+    }
+
+    return global[REQUEST_CACHE_STORAGE_KEY];
+}
+
+/**
+ * Build a cache key for the given scope and params.
+ * @param {String} scope Cache scope name
+ * @param {Object} params Parameters contributing to the cache key
+ * @returns {String} Serialized cache key
+ */
+function getRequestCacheKey(scope, params) {
+    return `${scope}:${JSON.stringify(params)}`;
+}
+
+/**
+ * Resolve a value using the current request-local cache when available.
+ * @param {Object} config Cache configuration
+ * @param {String} config.scope Cache scope name
+ * @param {Object} config.params Parameters contributing to the cache key
+ * @param {Function} config.fetcher Function that resolves the uncached value
+ * @param {Function} [config.shouldCache] Predicate deciding whether to keep the resolved value cached
+ * @returns {Promise<*>} Cached or newly fetched result
+ */
+function cacheBy({ scope, params, fetcher, shouldCache }) {
+    const requestCache = getRequestCacheStorage().getStore() || null;
+
+    if (!requestCache) {
+        return fetcher();
+    }
+
+    const cacheKey = getRequestCacheKey(scope, params);
+
+    if (requestCache.has(cacheKey)) {
+        return requestCache.get(cacheKey);
+    }
+
+    requestCache.set(
+        cacheKey,
+        Promise.resolve()
+            .then(fetcher)
+            .then(result => {
+                if (shouldCache && !shouldCache(result)) {
+                    requestCache.delete(cacheKey);
+                }
+
+                return result;
+            })
+            .catch(err => {
+                requestCache.delete(cacheKey);
+                throw err;
+            })
+    );
+
+    return requestCache.get(cacheKey);
+}
+
+module.exports = {
+    cacheBy,
+    getRequestCacheStorage
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -928,6 +928,62 @@ describe('index', function () {
                     }
                 );
         });
+
+        it('reuses request-local cache entries', async () => {
+            const testResponse = {
+                full_name: 'screwdriver-cd/models',
+                default_branch: 'master',
+                private: false
+            };
+            const requestCache = new Map();
+
+            githubMock.request.resolves({ data: testResponse });
+
+            const first = await scm.withRequestCache(requestCache, () =>
+                scm.lookupScmUri({
+                    scmUri,
+                    token: 'sometoken'
+                })
+            );
+            const second = await scm.withRequestCache(requestCache, () =>
+                scm.lookupScmUri({
+                    scmUri,
+                    token: 'sometoken'
+                })
+            );
+
+            assert.deepEqual(first, second);
+            assert.calledOnce(githubMock.request);
+        });
+
+        it('does not reuse request-local cache entries across scmRepo privateRepo values', async () => {
+            const requestCache = new Map();
+            const publicRepoConfig = {
+                scmUri,
+                scmRepo: {
+                    name: 'screwdriver-cd/models',
+                    branch: 'targetBranch',
+                    privateRepo: false
+                },
+                token: 'sometoken'
+            };
+            const privateRepoConfig = {
+                scmUri,
+                scmRepo: {
+                    name: 'screwdriver-cd/models',
+                    branch: 'targetBranch',
+                    privateRepo: true
+                },
+                token: 'sometoken'
+            };
+
+            const first = await scm.withRequestCache(requestCache, () => scm.lookupScmUri(publicRepoConfig));
+            const second = await scm.withRequestCache(requestCache, () => scm.lookupScmUri(privateRepoConfig));
+
+            assert.strictEqual(first.privateRepo, false);
+            assert.strictEqual(second.privateRepo, true);
+            assert.notCalled(githubMock.request);
+        });
     });
 
     describe('updateCommitStatus', () => {
@@ -1313,6 +1369,20 @@ jobs:
                     ref: 'master'
                 });
             });
+        });
+
+        it('reuses request-local cache entries', async () => {
+            const requestCache = new Map();
+
+            githubMock.repos.getContent.resolves({ data: returnData });
+
+            const first = await scm.withRequestCache(requestCache, () => scm.getFile(config));
+            const second = await scm.withRequestCache(requestCache, () => scm.getFile(config));
+
+            assert.deepEqual(first, expectedYaml);
+            assert.deepEqual(second, expectedYaml);
+            assert.calledOnce(githubMock.request);
+            assert.calledOnce(githubMock.repos.getContent);
         });
 
         it('promises to get content when rootDir exists', () => {
@@ -2147,6 +2217,29 @@ jobs:
                     assert.strictEqual(result, 'github.com:8675309:main');
                     assert.calledWith(githubMock.repos.get, sinon.match(repoInfo));
                 });
+        });
+
+        it('reuses request-local cache entries', async () => {
+            const requestCache = new Map();
+
+            githubMock.repos.get.resolves({ data: repoData });
+
+            const first = await scm.withRequestCache(requestCache, () =>
+                scm.parseUrl({
+                    checkoutUrl,
+                    token
+                })
+            );
+            const second = await scm.withRequestCache(requestCache, () =>
+                scm.parseUrl({
+                    checkoutUrl,
+                    token
+                })
+            );
+
+            assert.strictEqual(first, 'github.com:8675309:boat');
+            assert.strictEqual(second, 'github.com:8675309:boat');
+            assert.calledOnce(githubMock.repos.get);
         });
 
         it('rejects when unable to match', () => {
@@ -3382,6 +3475,30 @@ jobs:
                 assert.instanceOf(err, Error);
                 assert.strictEqual(testError.message, err.message);
             });
+        });
+
+        it('reuses request-local cache entries when mergeable is resolved', async () => {
+            const requestCache = new Map();
+
+            githubMock.pulls.get.resolves({ data: testPrGet });
+
+            const first = await scm.withRequestCache(requestCache, () => scm._getPrInfo(config));
+            const second = await scm.withRequestCache(requestCache, () => scm._getPrInfo(config));
+
+            assert.deepEqual(first, second);
+            assert.calledOnce(githubMock.request);
+            assert.calledOnce(githubMock.pulls.get);
+        });
+
+        it('does not cache unresolved mergeability responses', async () => {
+            const requestCache = new Map();
+
+            githubMock.pulls.get.resolves({ data: testPrGetNullMergeable });
+
+            await scm.withRequestCache(requestCache, () => scm._getPrInfo(config));
+            await scm.withRequestCache(requestCache, () => scm._getPrInfo(config));
+
+            assert.calledTwice(githubMock.pulls.get);
         });
     });
 


### PR DESCRIPTION
## Context

Webhook handling can repeat the same SCM reads multiple times within a single request.
In scm-github, operations such as repository lookup, file fetches, PR info fetches, and author/commit decoration can re-hit the same GitHub endpoints during one webhook flow, which adds avoidable latency and load.

We want to reuse those repeated results within the scope of a single request without changing behavior across requests.

## Objective

Introduce request-local caching in scm-github for repeated SCM operations during the same request.

This PR:
- adds an AsyncLocalStorage-backed request cache helper
- caches repeated scm-github lookups such as `lookupScmUri`, `getFile`, `getOpenedPRs`, `getRepoInfo`, `decorateAuthor`, `decorateCommit`, and `getPrInfo`
- avoids caching failed lookups and unresolved PR mergeability results
- keeps cache keys scoped to the request and to the relevant lookup inputs

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- https://github.com/screwdriver-cd/scm-router/pull/40
- https://github.com/screwdriver-cd/screwdriver/pull/3494

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
