### PR TITLE
fix: prefer x-hub-signature-256 for webhook signature verification

### DIFF
--- a/index.js
+++ b/index.js
@@ -1705,7 +1705,7 @@ class GithubScm extends Scm {
      *                                   payload
      */
     async _parseHook(payloadHeaders, webhookPayload) {
-        const signature = payloadHeaders['x-hub-signature'];
+        const signature = payloadHeaders['x-hub-signature-256'] || payloadHeaders['x-hub-signature'];
         const type = payloadHeaders['x-github-event'];
         const hookId = payloadHeaders['x-github-delivery'];
         const scmContexts = this._getScmContexts();
@@ -1714,9 +1714,13 @@ class GithubScm extends Scm {
 
         const checkoutSshHost = this.config.gheHost ? this.config.gheHost : 'github.com';
 
+        if (!signature) {
+            throwError('Missing webhook signature', 400);
+        }
+
         // eslint-disable-next-line no-underscore-dangle
         if (!(await verify(this.config.secret, webhookPayload, signature))) {
-            throwError('Invalid x-hub-signature', 400);
+            throwError('Invalid webhook signature', 400);
         }
 
         const parsedWebhookPayload = JSON.parse(webhookPayload);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2115,7 +2115,52 @@ jobs:
                     assert.fail('This should not fail the tests');
                 })
                 .catch(err => {
-                    assert.equal(err.message, 'Invalid x-hub-signature');
+                    assert.equal(err.message, 'Invalid webhook signature');
+                    assert.strictEqual(err.statusCode, 400);
+                });
+        });
+
+        it('accepts x-hub-signature-256 as the webhook signature', () => {
+            const payloadText = JSON.stringify(testPayloadPush);
+            const headers = {
+                'x-hub-signature-256': `sha256=${crypto
+                    .createHmac('sha256', 'somesecret')
+                    .update(payloadText)
+                    .digest('hex')}`,
+                'x-github-event': 'push',
+                'x-github-delivery': '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29'
+            };
+
+            return scm.parseHook(headers, payloadText).then(result => {
+                assert.deepEqual(result, {
+                    action: 'push',
+                    branch: 'master',
+                    checkoutUrl: 'git@github.com:baxterthehacker/public-repo.git',
+                    sha: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c',
+                    type: 'repo',
+                    username: 'baxterthehacker2',
+                    commitAuthors: ['baxterthehacker'],
+                    lastCommitMessage: 'lastcommitmessage',
+                    hookId: '3c77bf80-9a2f-11e6-80d6-72f7fe03ea29',
+                    scmContext: 'github:github.com',
+                    ref: 'refs/heads/master',
+                    addedFiles: ['README.md'],
+                    modifiedFiles: ['README.md', 'package.json'],
+                    removedFiles: ['screwdriver.yaml']
+                });
+            });
+        });
+
+        it('rejects webhooks with no signature header', () => {
+            delete testHeaders['x-hub-signature'];
+
+            return scm
+                .parseHook(testHeaders, JSON.stringify(testPayloadPush))
+                .then(() => {
+                    assert.fail('This should not fail the tests');
+                })
+                .catch(err => {
+                    assert.match(err.message, /Missing webhook signature/);
                     assert.strictEqual(err.statusCode, 400);
                 });
         });


### PR DESCRIPTION
## Summary
- `_parseHook` now reads `x-hub-signature-256` first and falls back to `x-hub-signature` only when the SHA-256 header is absent.
- Reject deliveries that supply neither header with HTTP 400.

## Test plan
- New unit test exercises the SHA-256 header path.
- New unit test asserts a missing-signature delivery is rejected with 400.
- Existing SHA-1 test continues to pass via the backward-compatible fallback.
