### PR TITLE
fix: confine _getFile path within rootDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -1367,7 +1367,27 @@ class GithubScm extends Scm {
                     }
 
                     ({ owner, repo, branch, rootDir } = await this.lookupScmUri(lookupConfig));
-                    fullPath = rootDir ? Path.join(rootDir, path) : path;
+
+                    // Reject explicit traversal sequences and confine the resolved path within
+                    // rootDir when set. These are git paths, always '/'-separated, so use
+                    // Path.posix.* regardless of the host OS.
+                    const joined = rootDir ? Path.posix.join(rootDir, path) : path;
+
+                    if (/(^|\/)\.\.(\/|$)/.test(joined)) {
+                        throwError('Path traversal detected', 400);
+                    }
+
+                    if (rootDir) {
+                        const base = `${Path.posix.normalize(rootDir.replace(/^\/+|\/+$/g, ''))}/`;
+                        const normalized = Path.posix.normalize(joined);
+
+                        if (!normalized.startsWith(base) && normalized !== base.slice(0, -1)) {
+                            throwError('Path outside repository rootDir', 403);
+                        }
+                        fullPath = normalized;
+                    } else {
+                        fullPath = Path.posix.normalize(joined);
+                    }
                 }
 
                 try {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1492,6 +1492,22 @@ jobs:
                     assert.strictEqual(error.statusCode, 403);
                 });
         });
+
+        it('rejects getFile when the path contains traversal segments', () => {
+            return scm
+                .getFile({
+                    scmUri: 'github.com:123456:master',
+                    path: '../etc/passwd',
+                    token: 'fake-token'
+                })
+                .then(
+                    () => assert.fail('expected getFile to reject'),
+                    err => {
+                        assert.match(err.message, /Path traversal detected/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+        });
     });
 
     describe('_getRepoInfo', () => {


### PR DESCRIPTION
## Summary
- `_getFile` now rejects explicit `..` traversal segments in the requested path.
- When `rootDir` is set, the resolved path must still start with `rootDir`; otherwise we throw 403 `Path outside repository rootDir`.
- All path operations use `Path.posix.*` since these are git repository paths.

## Test plan
- New unit test asserts `getFile` rejects `../etc/passwd` with 400.
- Existing happy-path `getFile` tests continue to pass.
