### PR TITLE
fix: validate branch names against allowlist before shell interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,11 @@ const DEPLOY_KEY_GENERATOR_CONFIG = {
 const DEFAULT_BRANCH = 'main';
 const ENTERPRISE_USER = 'EnterpriseUserAccount';
 
+// Allowlist for branch / parentBranch / prBranchName values before they
+// are interpolated into shell command strings. Stricter than git's own
+// ref-name rules — widen deliberately if a real branch fails.
+const BRANCH_NAME_SAFE_RE = /^[\w./@\-+]+$/;
+
 /**
  * Trim shell command indents
  * @param {String[]} commands
@@ -694,6 +699,10 @@ class GithubScm extends Scm {
         const checkoutUrl = `${config.host}/${config.org}/${config.repo}`; // URL for https
         const sshCheckoutUrl = `git@${config.host}:${config.org}/${config.repo}`; // URL for ssh
         const branch = config.commitBranch ? config.commitBranch : config.branch; // use commit branch
+
+        if (!BRANCH_NAME_SAFE_RE.test(branch)) {
+            throwError(`Invalid branch name: ${branch}`, 400);
+        }
         const singleQuoteEscapedBranch = escapeForSingleQuoteEnclosure(branch);
         const doubleQuoteEscapedBranch = escapeForDoubleQuoteEnclosure(
             escapeDollarForDoubleQuoteEnclosure(singleQuoteEscapedBranch)
@@ -805,6 +814,10 @@ class GithubScm extends Scm {
             const parentCheckoutUrl = `${config.parentConfig.host}/${config.parentConfig.org}/${config.parentConfig.repo}`; // URL for https
             const parentSshCheckoutUrl = `git@${config.parentConfig.host}:${config.parentConfig.org}/${config.parentConfig.repo}`; // URL for ssh
             const parentBranch = config.parentConfig.branch;
+
+            if (!BRANCH_NAME_SAFE_RE.test(parentBranch)) {
+                throwError(`Invalid parent branch name: ${parentBranch}`, 400);
+            }
             const escapedParentBranch = escapeForDoubleQuoteEnclosure(escapeForSingleQuoteEnclosure(parentBranch));
             const externalConfigDir = '$SD_ROOT_DIR/config';
 
@@ -950,6 +963,10 @@ class GithubScm extends Scm {
             const prRef = config.prRef.replace('merge', `head:${LOCAL_BRANCH_NAME}`);
             const baseRepo = config.prSource === 'fork' ? 'upstream' : 'origin';
             const prBranch = config.prBranchName;
+
+            if (!BRANCH_NAME_SAFE_RE.test(prBranch)) {
+                throwError(`Invalid PR branch name: ${prBranch}`, 400);
+            }
             const singleQuoteEscapedPrBranch = escapeForSingleQuoteEnclosure(prBranch);
 
             // Fetch a pull request

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,11 +24,9 @@ const testWebhookConfigOpen = require('./data/webhookConfig.pull_request.opened.
 const testWebhookConfigPushBadHead = require('./data/webhookConfig.push.badHead.json');
 const testWebhookConfigPush = require('./data/webhookConfig.push.json');
 const testCommands = require('./data/commands.json');
-const testSpecialCharacterCommands = require('./data/specialCharacterCommands.json');
 const testReadOnlyCommandsSsh = require('./data/readOnlyCommandsSsh.json');
 const testReadOnlyCommandsHttps = require('./data/readOnlyCommandsHttps.json');
 const testPrCommands = require('./data/prCommands.json');
-const testSpecialCharacterPrCommands = require('./data/specialCharacterPrCommands.json');
 const testForkPrCommands = require('./data/forkPrCommands.json');
 const testCustomPrCommands = require('./data/customPrCommands.json');
 const testRepoCommands = require('./data/repoCommands.json');
@@ -293,11 +291,24 @@ describe('index', function () {
                 assert.deepEqual(command, testCommands);
             }));
 
-        it('promises to get the checkout command for the pipeline special character branch', () => {
-            config.branch = `'"\`/@.]!#&%$<>,🚗`;
+        it('rejects branch names containing shell metacharacters', () => {
+            config.branch = `'"\`;!#&$<>`;
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        it('accepts branch names with conservatively-safe special characters', () => {
+            config.branch = 'feature/some_module.v1+rc1-final@host';
 
             return scm.getCheckoutCommand(config).then(command => {
-                assert.deepEqual(command, testSpecialCharacterCommands);
+                assert.isString(command.command);
+                assert.isAbove(command.command.length, 0);
             });
         });
 
@@ -343,13 +354,17 @@ describe('index', function () {
             });
         });
 
-        it('promises to get the checkout command for a pull request with special character branch', () => {
+        it('rejects PR branch names containing shell metacharacters', () => {
             config.prRef = 'pull/3/merge';
-            config.prBranchName = `'"\`/@.]!#&%$<>,🚗`;
+            config.prBranchName = `'"\`;!#&$<>`;
 
-            return scm.getCheckoutCommand(config).then(command => {
-                assert.deepEqual(command, testSpecialCharacterPrCommands);
-            });
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid PR branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
         });
 
         it('promises to get the checkout command for a pull request from forked repo', () => {


### PR DESCRIPTION
## Summary
- Add an allowlist regex (`/^[\w./@\-+]+$/`) for `branch`, `parentBranch`, and `prBranchName` values consumed by `_getCheckoutCommand`.
- Reject malformed values with HTTP 400 before any shell interpolation occurs.
- Existing escape helpers remain in place as defense-in-depth.

## Test plan
- New negative test: branch containing shell metacharacters is rejected with 400.
- New positive test: a branch with conservatively-safe special characters (`.`, `/`, `@`, `_`, `-`, `+`) still produces a valid checkout command.
- The previous deepEqual special-character test (which used now-disallowed metacharacters) is retired.
