### PR TITLE
fix: Add whitelist of characters allowed in branch names

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,19 @@ const ENTERPRISE_USER = 'EnterpriseUserAccount';
 // Allowlist for branch / parentBranch / prBranchName values before they
 // are interpolated into shell command strings. Stricter than git's own
 // ref-name rules — widen deliberately if a real branch fails.
-const BRANCH_NAME_SAFE_RE = /^[\w./@\-+]+$/;
+const allowedChars = [
+    '0-9', // ASCII digits
+    'A-Za-z', // ASCII alphabets
+    '\\p{Script=Hiragana}', // Hiragana
+    '\\p{Script=Katakana}', // Katakana
+    '\\p{Script=Han}', // CJK Han (Kanji)
+    '\\p{Script=Hangul}', // Hangul
+    '._/@\\-+', // ASCII symbols (Common filename-safe symbols allowed by Git)
+    '\\u3005' // Ideographic iteration mark: 々
+];
+const BRANCH_NAME_ALLOWED_CHAR_RE = new RegExp(`^[${allowedChars.join('')}]+$`, 'u');
+const BRANCH_NAME_DANGEROUS_CHAR_RE = /['"`;!#$&<>|]/u;
+const BRANCH_NAME_FORBIDDEN_SEQUENCE_RE = /(\/\/|(^|\/)\.|\/$|\.\.|@\{|\.lock$|\.$)/;
 
 /**
  * Trim shell command indents
@@ -109,6 +121,41 @@ function throwError(errorReason, errorCode = 500) {
 
     err.statusCode = errorCode;
     throw err;
+}
+
+/**
+ * Detect ASCII control characters (0x00-0x1F, 0x7F).
+ * @param  {String} name branch-like name
+ * @returns {Boolean}    true when control chars are included
+ */
+function hasControlCharacters(name) {
+    for (const char of name) {
+        const codePoint = char.codePointAt(0);
+
+        if (codePoint <= 0x1f || codePoint === 0x7f) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Validate branch-like names used in shell command interpolation.
+ * @param  {String} name branch-like name
+ * @returns {Boolean}    true when the name is safe
+ */
+function isSafeBranchName(name) {
+    if (typeof name !== 'string' || name.length === 0) {
+        return false;
+    }
+
+    return (
+        BRANCH_NAME_ALLOWED_CHAR_RE.test(name) &&
+        !hasControlCharacters(name) &&
+        !BRANCH_NAME_DANGEROUS_CHAR_RE.test(name) &&
+        !BRANCH_NAME_FORBIDDEN_SEQUENCE_RE.test(name)
+    );
 }
 
 const SENSITIVE_KEY_RE = /token|authoriz|authentic|secret|password|cookie|^auth$|api[_-]?key/i;
@@ -757,7 +804,7 @@ class GithubScm extends Scm {
         const sshCheckoutUrl = `git@${config.host}:${config.org}/${config.repo}`; // URL for ssh
         const branch = config.commitBranch ? config.commitBranch : config.branch; // use commit branch
 
-        if (!BRANCH_NAME_SAFE_RE.test(branch)) {
+        if (!isSafeBranchName(branch)) {
             throwError(`Invalid branch name: ${branch}`, 400);
         }
         const singleQuoteEscapedBranch = escapeForSingleQuoteEnclosure(branch);
@@ -872,7 +919,7 @@ class GithubScm extends Scm {
             const parentSshCheckoutUrl = `git@${config.parentConfig.host}:${config.parentConfig.org}/${config.parentConfig.repo}`; // URL for ssh
             const parentBranch = config.parentConfig.branch;
 
-            if (!BRANCH_NAME_SAFE_RE.test(parentBranch)) {
+            if (!isSafeBranchName(parentBranch)) {
                 throwError(`Invalid parent branch name: ${parentBranch}`, 400);
             }
             const escapedParentBranch = escapeForDoubleQuoteEnclosure(escapeForSingleQuoteEnclosure(parentBranch));
@@ -1022,7 +1069,7 @@ class GithubScm extends Scm {
             const baseRepo = config.prSource === 'fork' ? 'upstream' : 'origin';
             const prBranch = config.prBranchName;
 
-            if (!BRANCH_NAME_SAFE_RE.test(prBranch)) {
+            if (!isSafeBranchName(prBranch)) {
                 throwError(`Invalid PR branch name: ${prBranch}`, 400);
             }
             const singleQuoteEscapedPrBranch = escapeForSingleQuoteEnclosure(prBranch);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -580,7 +580,7 @@ describe('index', function () {
 
         it('rejects parent branch names containing unsupported unicode categories', () => {
             config.parentConfig = {
-                branch: '①②③※＆β',
+                branch: 'feature/①②③※↑→−「」【】＆（）０１２３：＿ｍ./@+-()=,¥×Đα',
                 host: 'github.com',
                 org: 'screwdriver-cd',
                 repo: 'parent-to-guide',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -273,6 +273,28 @@ describe('index', function () {
 
     describe('getCheckoutCommand', () => {
         let config;
+        const allowedBranchCategorySamples = [
+            { category: 'ASCII digits', value: 'feature/20260615' },
+            { category: 'ASCII uppercase', value: 'feature/RELEASE' },
+            { category: 'ASCII lowercase', value: 'feature/release' },
+            { category: 'hiragana', value: 'feature/ひらがなゔ' },
+            { category: 'katakana', value: 'feature/カタカナヴ' },
+            { category: 'cjk', value: 'feature/漢字東京' },
+            { category: 'hangul', value: 'feature/한글테스트' }
+        ];
+        const rejectedBranchCategorySamples = [
+            { category: 'ASCII symbols', value: 'feature/a+b.c=d,e@_](-)%' },
+            { category: 'extended latin', value: 'feature/Angstrom-Ångström-Đ' },
+            { category: 'greek', value: 'feature/alpha-β' },
+            { category: 'control-special', value: 'feature/zero\u200bwidth※↑→−' },
+            { category: 'circled numbers', value: 'feature/④⑥⑧' },
+            { category: 'jp punctuation', value: 'feature/、。々' },
+            { category: 'jp brackets', value: 'feature/「名」【称】' },
+            { category: 'variation selector', value: 'feature/テスト\ufe0f' },
+            { category: 'fullwidth symbols', value: 'feature/＆（）：＞＿' },
+            { category: 'fullwidth digits', value: 'feature/９８７' },
+            { category: 'fullwidth letters', value: 'feature/Ｍｍ' }
+        ];
 
         beforeEach(() => {
             config = {
@@ -292,7 +314,7 @@ describe('index', function () {
             }));
 
         it('rejects branch names containing shell metacharacters', () => {
-            config.branch = `'"\`;!#&$<>`;
+            config.branch = `'"\`;!#&$<>|`;
 
             return scm.getCheckoutCommand(config).then(
                 () => assert.fail('expected getCheckoutCommand to reject'),
@@ -303,12 +325,91 @@ describe('index', function () {
             );
         });
 
+        [`'`, '"', '`', ';', '!', '#', '&', '$', '<', '>', '|'].forEach(char => {
+            it(`rejects branch names containing shell metacharacter: ${char}`, () => {
+                config.branch = `branch${char}name`;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+            });
+        });
+
+        ['branch..name', 'branch@{name', 'branch/.name', 'branch/', '.branch', 'branch.lock'].forEach(branchName => {
+            it(`rejects branch names with forbidden git ref sequence: ${branchName}`, () => {
+                config.branch = branchName;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+            });
+        });
+
         it('accepts branch names with conservatively-safe special characters', () => {
             config.branch = 'feature/some_module.v1+rc1-final@host';
 
             return scm.getCheckoutCommand(config).then(command => {
                 assert.isString(command.command);
                 assert.isAbove(command.command.length, 0);
+            });
+        });
+
+        it('rejects branch names containing unsupported unicode categories', () => {
+            config.branch = 'feature/①②③※↑→−「」【】＆（）０１２３：＿ｍ./@+-()=,¥×Đα';
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        allowedBranchCategorySamples.forEach(sample => {
+            it(`accepts branch names from category: ${sample.category}`, () => {
+                config.branch = sample.value;
+
+                return scm.getCheckoutCommand(config).then(command => {
+                    assert.isString(command.command);
+                    assert.isAbove(command.command.length, 0);
+                });
+            });
+        });
+
+        rejectedBranchCategorySamples.forEach(sample => {
+            it(`rejects branch names from unsupported category: ${sample.category}`, () => {
+                config.branch = sample.value;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+            });
+        });
+
+        ['🚗', ':', '[', '\\'].forEach(char => {
+            it(`rejects branch names containing unsupported character: ${char}`, () => {
+                config.branch = `branch${char}name`;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
             });
         });
 
@@ -356,7 +457,35 @@ describe('index', function () {
 
         it('rejects PR branch names containing shell metacharacters', () => {
             config.prRef = 'pull/3/merge';
-            config.prBranchName = `'"\`;!#&$<>`;
+            config.prBranchName = `'"\`;!#&$<>|`;
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid PR branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
+        });
+
+        [`'`, '"', '`', ';', '!', '#', '&', '$', '<', '>', '|'].forEach(char => {
+            it(`rejects PR branch names containing shell metacharacter: ${char}`, () => {
+                config.prRef = 'pull/3/merge';
+                config.prBranchName = `branch${char}name`;
+
+                return scm.getCheckoutCommand(config).then(
+                    () => assert.fail('expected getCheckoutCommand to reject'),
+                    err => {
+                        assert.match(err.message, /Invalid PR branch name/);
+                        assert.equal(err.statusCode, 400);
+                    }
+                );
+            });
+        });
+
+        it('rejects PR branch names containing unsupported unicode categories', () => {
+            config.prRef = 'pull/3/merge';
+            config.prBranchName = 'pr/①②③※↑→−「」【】＆（）０１２３：＿ｍ./@+-()=,¥×Đα';
 
             return scm.getCheckoutCommand(config).then(
                 () => assert.fail('expected getCheckoutCommand to reject'),
@@ -447,6 +576,24 @@ describe('index', function () {
             return scm.getCheckoutCommand(config).then(command => {
                 assert.deepEqual(command, testChildCommands);
             });
+        });
+
+        it('rejects parent branch names containing unsupported unicode categories', () => {
+            config.parentConfig = {
+                branch: '①②③※＆β',
+                host: 'github.com',
+                org: 'screwdriver-cd',
+                repo: 'parent-to-guide',
+                sha: '54321'
+            };
+
+            return scm.getCheckoutCommand(config).then(
+                () => assert.fail('expected getCheckoutCommand to reject'),
+                err => {
+                    assert.match(err.message, /Invalid parent branch name/);
+                    assert.equal(err.statusCode, 400);
+                }
+            );
         });
     });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

follow up: https://github.com/screwdriver-cd/scm-github/pull/263

Currently, Japanese and Hangul characters cannot be used.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Enable the following characters
- Japanese Hiragana
- Japanese Katakana
- Japanese Kanji
- Hangul
- Symbols that were originally configurable before PR(._/@\\-+)

Indicate forbidden characters
- Even when using Japanese characters, full-width alphanumeric characters are prohibited.
- Full-width special characters are also forbidden.
- Emojis are not allowed

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/scm-github/pull/263

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
