### PR TITLE
fix: Add whitelist characters 

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,16 +63,25 @@ const ENTERPRISE_USER = 'EnterpriseUserAccount';
 const allowedChars = [
     '0-9', // ASCII digits
     'A-Za-z', // ASCII alphabets
-    '\\p{Script=Hiragana}', // Hiragana
-    '\\p{Script=Katakana}', // Katakana
-    '\\p{Script=Han}', // CJK Han (Kanji)
-    '\\p{Script=Hangul}', // Hangul
-    '._/@\\-+', // ASCII symbols (Common filename-safe symbols allowed by Git)
-    '\\u3005' // Ideographic iteration mark: 々
+    '\\p{Script_Extensions=Hiragana}', // Hiragana
+    '\\p{Script_Extensions=Katakana}', // Katakana
+    '\\p{Script_Extensions=Han}', // CJK Han (Kanji)
+    '\\p{Script_Extensions=Hangul}', // Hangul
+    '\\p{Script_Extensions=Greek}', // Greek (e.g. α β γ)
+    ',._/#%@\\-+=()', // ASCII symbols (Common filename-safe symbols allowed by Git)
+    '\\u3005', // Ideographic iteration mark: 々
+    '\\u3010', // Full-width opening black lenticular bracket: 【
+    '\\u3011', // Full-width closing black lenticular bracket: 】
+    '\\uff1a', // Full-width colon: ：
+    '\\uff08', // Full-width opening parenthesis: （
+    '\\uff09', // Full-width closing parenthesis: ）
+    '\\u200b', // Full-width space
+    '\\uff10-\\uff19', // Full-width digits: ０-９
+    '\\uff21-\\uff3a', // Full-width uppercase letters: Ａ-Ｚ
+    '\\uff41-\\uff5a' // Full-width lowercase letters: ａ-ｚ
 ];
 const BRANCH_NAME_ALLOWED_CHAR_RE = new RegExp(`^[${allowedChars.join('')}]+$`, 'u');
-const BRANCH_NAME_DANGEROUS_CHAR_RE = /['"`;!#$&<>|]/u;
-const BRANCH_NAME_FORBIDDEN_SEQUENCE_RE = /(\/\/|(^|\/)\.|\/$|\.\.|@\{|\.lock$|\.$)/;
+const BRANCH_NAME_DANGEROUS_CHAR_RE = /['"`;!$&<>|]/u;
 
 /**
  * Trim shell command indents
@@ -153,8 +162,7 @@ function isSafeBranchName(name) {
     return (
         BRANCH_NAME_ALLOWED_CHAR_RE.test(name) &&
         !hasControlCharacters(name) &&
-        !BRANCH_NAME_DANGEROUS_CHAR_RE.test(name) &&
-        !BRANCH_NAME_FORBIDDEN_SEQUENCE_RE.test(name)
+        !BRANCH_NAME_DANGEROUS_CHAR_RE.test(name)
     );
 }
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ const allowedChars = [
     '\\uff1a', // Full-width colon: ：
     '\\uff08', // Full-width opening parenthesis: （
     '\\uff09', // Full-width closing parenthesis: ）
-    '\\u200b', // Full-width space
+    '\\u3000', // Full-width space
     '\\uff10-\\uff19', // Full-width digits: ０-９
     '\\uff21-\\uff3a', // Full-width uppercase letters: Ａ-Ｚ
     '\\uff41-\\uff5a' // Full-width lowercase letters: ａ-ｚ

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -279,13 +279,14 @@ describe('index', function () {
             { category: 'ASCII lowercase', value: 'feature/release' },
             { category: 'hiragana', value: 'feature/ひらがなゔー' },
             { category: 'katakana', value: 'feature/カタカナヴー' },
-            { category: 'cjk', value: 'feature/漢字東京々' },
+            { category: 'cjk', value: 'feature/漢字東京' },
             { category: 'hangul', value: 'feature/한글테스트' },
             { category: 'greek', value: 'feature/alpha-β' },
+            { category: 'jp punctuation', value: 'feature/、。々' },
+            { category: 'jp brackets', value: 'feature/「名」【称】' }
             { category: 'fullwidth symbols', value: 'feature/（）：' },
             { category: 'fullwidth digits', value: 'feature/９８７' },
             { category: 'fullwidth letters', value: 'feature/Ｍｍ' },
-            { category: 'jp brackets', value: 'feature/「名」【称】' }
         ];
         const rejectedBranchCategorySamples = [
             { category: 'ASCII symbols', value: 'feature/a+b.c=d,e@_](-)%' },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -277,23 +277,21 @@ describe('index', function () {
             { category: 'ASCII digits', value: 'feature/20260615' },
             { category: 'ASCII uppercase', value: 'feature/RELEASE' },
             { category: 'ASCII lowercase', value: 'feature/release' },
-            { category: 'hiragana', value: 'feature/ひらがなゔ' },
-            { category: 'katakana', value: 'feature/カタカナヴ' },
-            { category: 'cjk', value: 'feature/漢字東京' },
-            { category: 'hangul', value: 'feature/한글테스트' }
+            { category: 'hiragana', value: 'feature/ひらがなゔー' },
+            { category: 'katakana', value: 'feature/カタカナヴー' },
+            { category: 'cjk', value: 'feature/漢字東京々' },
+            { category: 'hangul', value: 'feature/한글테스트' },
+            { category: 'greek', value: 'feature/alpha-β' },
+            { category: 'fullwidth digits', value: 'feature/９８７' },
+            { category: 'fullwidth letters', value: 'feature/Ｍｍ' }
         ];
         const rejectedBranchCategorySamples = [
             { category: 'ASCII symbols', value: 'feature/a+b.c=d,e@_](-)%' },
             { category: 'extended latin', value: 'feature/Angstrom-Ångström-Đ' },
-            { category: 'greek', value: 'feature/alpha-β' },
             { category: 'control-special', value: 'feature/zero\u200bwidth※↑→−' },
             { category: 'circled numbers', value: 'feature/④⑥⑧' },
-            { category: 'jp punctuation', value: 'feature/、。々' },
-            { category: 'jp brackets', value: 'feature/「名」【称】' },
             { category: 'variation selector', value: 'feature/テスト\ufe0f' },
-            { category: 'fullwidth symbols', value: 'feature/＆（）：＞＿' },
-            { category: 'fullwidth digits', value: 'feature/９８７' },
-            { category: 'fullwidth letters', value: 'feature/Ｍｍ' }
+            { category: 'fullwidth symbols', value: 'feature/＆＞＿' }
         ];
 
         beforeEach(() => {
@@ -325,7 +323,7 @@ describe('index', function () {
             );
         });
 
-        [`'`, '"', '`', ';', '!', '#', '&', '$', '<', '>', '|'].forEach(char => {
+        [`'`, '"', '`', ';', '!', '&', '$', '<', '>', '|'].forEach(char => {
             it(`rejects branch names containing shell metacharacter: ${char}`, () => {
                 config.branch = `branch${char}name`;
 
@@ -339,17 +337,14 @@ describe('index', function () {
             });
         });
 
-        ['branch..name', 'branch@{name', 'branch/.name', 'branch/', '.branch', 'branch.lock'].forEach(branchName => {
-            it(`rejects branch names with forbidden git ref sequence: ${branchName}`, () => {
+        ['branch..name', 'branch/.name', 'branch/', '.branch', 'branch.lock'].forEach(branchName => {
+            it(`accepts branch names without shell metacharacters: ${branchName}`, () => {
                 config.branch = branchName;
 
-                return scm.getCheckoutCommand(config).then(
-                    () => assert.fail('expected getCheckoutCommand to reject'),
-                    err => {
-                        assert.match(err.message, /Invalid branch name/);
-                        assert.equal(err.statusCode, 400);
-                    }
-                );
+                return scm.getCheckoutCommand(config).then(command => {
+                    assert.isString(command.command);
+                    assert.isAbove(command.command.length, 0);
+                });
             });
         });
 
@@ -468,7 +463,7 @@ describe('index', function () {
             );
         });
 
-        [`'`, '"', '`', ';', '!', '#', '&', '$', '<', '>', '|'].forEach(char => {
+        [`'`, '"', '`', ';', '!', '&', '$', '<', '>', '|'].forEach(char => {
             it(`rejects PR branch names containing shell metacharacter: ${char}`, () => {
                 config.prRef = 'pull/3/merge';
                 config.prBranchName = `branch${char}name`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -282,8 +282,10 @@ describe('index', function () {
             { category: 'cjk', value: 'feature/漢字東京々' },
             { category: 'hangul', value: 'feature/한글테스트' },
             { category: 'greek', value: 'feature/alpha-β' },
+            { category: 'fullwidth symbols', value: 'feature/（）：' },
             { category: 'fullwidth digits', value: 'feature/９８７' },
-            { category: 'fullwidth letters', value: 'feature/Ｍｍ' }
+            { category: 'fullwidth letters', value: 'feature/Ｍｍ' },
+            { category: 'jp brackets', value: 'feature/「名」【称】' }
         ];
         const rejectedBranchCategorySamples = [
             { category: 'ASCII symbols', value: 'feature/a+b.c=d,e@_](-)%' },
@@ -291,7 +293,7 @@ describe('index', function () {
             { category: 'control-special', value: 'feature/zero\u200bwidth※↑→−' },
             { category: 'circled numbers', value: 'feature/④⑥⑧' },
             { category: 'variation selector', value: 'feature/テスト\ufe0f' },
-            { category: 'fullwidth symbols', value: 'feature/＆＞＿' }
+            { category: 'fullwidth symbols', value: 'feature/＃＆＞＿' }
         ];
 
         beforeEach(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -337,17 +337,6 @@ describe('index', function () {
             });
         });
 
-        ['branch..name', 'branch/.name', 'branch/', '.branch', 'branch.lock'].forEach(branchName => {
-            it(`accepts branch names without shell metacharacters: ${branchName}`, () => {
-                config.branch = branchName;
-
-                return scm.getCheckoutCommand(config).then(command => {
-                    assert.isString(command.command);
-                    assert.isAbove(command.command.length, 0);
-                });
-            });
-        });
-
         it('accepts branch names with conservatively-safe special characters', () => {
             config.branch = 'feature/some_module.v1+rc1-final@host';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -283,10 +283,10 @@ describe('index', function () {
             { category: 'hangul', value: 'feature/한글테스트' },
             { category: 'greek', value: 'feature/alpha-β' },
             { category: 'jp punctuation', value: 'feature/、。々' },
-            { category: 'jp brackets', value: 'feature/「名」【称】' }
+            { category: 'jp brackets', value: 'feature/「名」【称】' },
             { category: 'fullwidth symbols', value: 'feature/（）：' },
             { category: 'fullwidth digits', value: 'feature/９８７' },
-            { category: 'fullwidth letters', value: 'feature/Ｍｍ' },
+            { category: 'fullwidth letters', value: 'feature/Ｍｍ' }
         ];
         const rejectedBranchCategorySamples = [
             { category: 'ASCII symbols', value: 'feature/a+b.c=d,e@_](-)%' },


### PR DESCRIPTION
## Context
follow up: https://github.com/screwdriver-cd/scm-github/pull/268

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
## Objective
Add more available characters
- Frequently Used Full-Width Characters
- Greek letters
- #, %, =, (, ) 
  - e.g., features/#1234

`BRANCH_NAME_FORBIDDEN_SEQUENCE_RE` is not needed because it is restricted by GitHub, so delete it

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/scm-github/pull/268
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
